### PR TITLE
feat: constitute attested delivery architecture (Mode B)

### DIFF
--- a/.github/workflows/build-attest.yml
+++ b/.github/workflows/build-attest.yml
@@ -1,0 +1,111 @@
+# Centralized reusable workflow: build a container, push it to GHCR by digest, then
+# sign + attest it via the isolated sign-and-attest workflow.
+#
+# This is the single entry point application repos call to produce an attested
+# image. The build runs in the caller's context (its Dockerfile/context); signing
+# and attestation happen inside the isolated sign-and-attest reusable workflow,
+# which the caller cannot modify (the SLSA Build L3 boundary). The image digest is
+# canonical; the commit-SHA tag is informational only.
+#
+# Caller MUST pin this workflow by full commit SHA:
+#   uses: zircote/.github/.github/workflows/build-attest.yml@<SHA>
+#
+# Primary sources:
+#   - docker/build-push-action (digest output): https://github.com/docker/build-push-action
+#   - GHCR (push by digest):                     https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+
+name: build-attest
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Image repository without tag/digest (e.g. ghcr.io/zircote/app)"
+        required: true
+        type: string
+      context:
+        description: "Docker build context path"
+        required: false
+        type: string
+        default: "."
+      dockerfile:
+        description: "Path to the Dockerfile"
+        required: false
+        type: string
+        default: "Dockerfile"
+      build-args:
+        description: "Newline-delimited build args passed to the build"
+        required: false
+        type: string
+        default: ""
+      sbom:
+        description: "Generate + attest a CycloneDX SBOM (via sign-and-attest)"
+        required: false
+        type: boolean
+        default: true
+      vuln-scan:
+        description: "Generate + attest a Grype vulnerability report (via sign-and-attest)"
+        required: false
+        type: boolean
+        default: true
+      cosign-version:
+        required: false
+        type: string
+        default: "v3.0.6"
+    outputs:
+      image-digest:
+        description: "The immutable sha256 digest of the pushed image"
+        value: ${{ jobs.build.outputs.image-digest }}
+      provenance-verified:
+        description: "true when sign-and-attest verified SLSA L3 in this run"
+        value: ${{ jobs.attest.outputs.provenance-verified }}
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Build and push (digest canonical, sha tag informational)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          build-args: ${{ inputs.build-args }}
+          push: true
+          tags: ${{ inputs.image-name }}:${{ github.sha }}
+          # SLSA L3 provenance + SBOM come from the isolated sign-and-attest
+          # workflow, NOT the caller-controlled build step.
+          provenance: false
+          sbom: false
+
+  attest:
+    needs: build
+    permissions:
+      id-token: write
+      attestations: write
+      packages: write
+      contents: read
+    uses: ./.github/workflows/sign-and-attest.yml
+    with:
+      image-name: ${{ inputs.image-name }}
+      image-digest: ${{ needs.build.outputs.image-digest }}
+      sbom: ${{ inputs.sbom }}
+      vuln-scan: ${{ inputs.vuln-scan }}
+      cosign-version: ${{ inputs.cosign-version }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   automerge:
-    uses: zircote/.github/.github/workflows/reusable-dependabot-automerge.yml@main
+    uses: ./.github/workflows/reusable-dependabot-automerge.yml
     secrets: inherit

--- a/.github/workflows/dora-emit.yml
+++ b/.github/workflows/dora-emit.yml
@@ -1,0 +1,116 @@
+# Centralized reusable workflow: emit a DORA deployment event + metric to Datadog.
+#
+# A deployment is defined as a production digest promotion. This workflow emits the
+# pipeline-side DORA signals (deployment event + deployment-frequency count, plus an
+# optional lead-time gauge), tagged by environment, service, status and authoring
+# cohort. The remaining signals of the five-event model (ArgoCD sync, PagerDuty
+# incident open/resolved for CFR/FDRT) are emitted by their own integrations.
+#
+# Caller MUST pin this workflow by full commit SHA.
+#
+# Primary sources:
+#   - Datadog Events API v1:  https://docs.datadoghq.com/api/latest/events/#post-an-event
+#   - Datadog Metrics API v1: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
+#   - DORA metrics in Datadog: https://docs.datadoghq.com/dora_metrics/
+
+name: dora-emit
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Deployment environment (DORA counts prod by default)"
+        required: true
+        type: string
+      service:
+        description: "Service name (Datadog service tag)"
+        required: true
+        type: string
+      status:
+        description: "Deployment outcome: success | failure"
+        required: true
+        type: string
+      git-sha:
+        description: "Commit SHA deployed"
+        required: true
+        type: string
+      image-digest:
+        description: "The promoted image digest (sha256:...)"
+        required: true
+        type: string
+      lead-time-seconds:
+        description: "PR-created to deploy lead time in seconds (0 if unknown)"
+        required: false
+        type: number
+        default: 0
+      authoring-cohort:
+        description: "AI-authoring cohort for DORA segmentation (optional)"
+        required: false
+        type: string
+        default: ""
+      dd-site:
+        description: "Datadog site (datadoghq.com, datadoghq.eu, us5.datadoghq.com, ...)"
+        required: false
+        type: string
+        default: "datadoghq.com"
+    secrets:
+      DD_API_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  emit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Emit DORA deployment event + metric to Datadog
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SITE: ${{ inputs.dd-site }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          SERVICE: ${{ inputs.service }}
+          STATUS: ${{ inputs.status }}
+          GIT_SHA: ${{ inputs.git-sha }}
+          IMAGE_DIGEST: ${{ inputs.image-digest }}
+          LEAD_TIME: ${{ inputs.lead-time-seconds }}
+          COHORT: ${{ inputs.authoring-cohort }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          case "${DD_SITE}" in
+            datadoghq.com|us3.datadoghq.com|us5.datadoghq.com|datadoghq.eu|ap1.datadoghq.com|ddog-gov.com) ;;
+            *) echo "::error::dd-site '${DD_SITE}' is not an allowed Datadog domain"; exit 1 ;;
+          esac
+          now="$(date +%s)"
+          alert_type="info"; [ "$STATUS" = "failure" ] && alert_type="error"
+
+          # Tag set (jq-built to avoid injection)
+          tags="$(jq -cn --arg env "$ENVIRONMENT" --arg svc "$SERVICE" \
+            --arg st "$STATUS" --arg co "$COHORT" '
+            ["env:\($env)","service:\($svc)","status:\($st)"]
+            + (if $co == "" then [] else ["ai_authoring_mode:\($co)"] end)')"
+
+          # 1) Deployment event
+          jq -cn --arg title "Deployment: $SERVICE -> $ENVIRONMENT ($STATUS)" \
+            --arg text "sha=$GIT_SHA digest=$IMAGE_DIGEST repo=$REPO" \
+            --arg at "$alert_type" --argjson tags "$tags" \
+            '{title:$title, text:$text, alert_type:$at, tags:$tags, source_type_name:"github_actions"}' \
+            | curl -fsS -X POST "https://api.${DD_SITE}/api/v1/events" \
+                -H "DD-API-KEY: ${DD_API_KEY}" -H 'Content-Type: application/json' -d @- >/dev/null
+
+          # 2) Deployment-frequency count metric
+          jq -cn --argjson now "$now" --argjson tags "$tags" \
+            '{series:[{metric:"zircote.dora.deployment", points:[[$now,1]], type:"count", tags:$tags}]}' \
+            | curl -fsS -X POST "https://api.${DD_SITE}/api/v1/series" \
+                -H "DD-API-KEY: ${DD_API_KEY}" -H 'Content-Type: application/json' -d @- >/dev/null
+
+          # 3) Lead-time gauge (only when known)
+          if [ "${LEAD_TIME}" != "0" ]; then
+            jq -cn --argjson now "$now" --argjson lt "${LEAD_TIME}" --argjson tags "$tags" \
+              '{series:[{metric:"zircote.dora.lead_time_seconds", points:[[$now,$lt]], type:"gauge", tags:$tags}]}' \
+              | curl -fsS -X POST "https://api.${DD_SITE}/api/v1/series" \
+                  -H "DD-API-KEY: ${DD_API_KEY}" -H 'Content-Type: application/json' -d @- >/dev/null
+          fi
+          echo "Emitted DORA deployment signals for ${SERVICE} -> ${ENVIRONMENT} (${STATUS})."

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,58 @@
+# Mirror pinned upstream container images into ghcr.io/zircote/mirror/*.
+#
+# Org policy: application repos pull and push ONLY ghcr.io. This workflow is
+# the single controlled ingress from external registries (Docker Hub, gcr.io).
+# `cosign copy` preserves digests, manifest lists, and any attached referrers.
+#
+# Add an image: append a matrix entry, merge, dispatch. Consumers reference
+# the mirror tag and never touch the upstream registry.
+
+name: mirror-images
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly Monday 06:00 UTC, keeps mirror tags current
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mirror-images
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # BuildKit builder image used by docker/setup-buildx-action
+          # (driver-opts: image=...) in consumer repos.
+          - source: docker.io/moby/buildkit:buildx-stable-1
+            dest: ghcr.io/zircote/mirror/buildkit:buildx-stable-1
+          # Rust builder base (ccab Dockerfile builder stage).
+          - source: docker.io/library/rust:1.96-alpine
+            dest: ghcr.io/zircote/mirror/rust:1.96-alpine
+          # Distroless runtime base (ccab Dockerfile runtime stage).
+          - source: gcr.io/distroless/static-debian12:nonroot
+            dest: ghcr.io/zircote/mirror/static-debian12:nonroot
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror ${{ matrix.source }}
+        env:
+          SOURCE: ${{ matrix.source }}
+          DEST: ${{ matrix.dest }}
+        run: cosign copy -f "${SOURCE}" "${DEST}"

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,64 @@
+# Centralized reusable workflow: assert every GitHub Actions `uses:` reference in
+# the caller is pinned to a full 40-character commit SHA.
+#
+# Mutable tags (@v4, @main) and floating refs (@master) are a supply-chain risk
+# (e.g. the trivy-action ecosystem compromise). Local reusable-workflow calls
+# (`uses: ./...`) and digest-pinned container actions (`uses: docker://...@sha256`)
+# are exempt. Fails the run on the first unpinned reference.
+#
+# Caller MUST pin this workflow by full commit SHA.
+#
+# Primary source:
+#   - Security hardening for GitHub Actions (pin actions to a full-length SHA):
+#     https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+
+name: pin-check
+
+on:
+  workflow_call:
+    inputs:
+      scan-dir:
+        description: "Directory to scan for workflow/action files"
+        required: false
+        type: string
+        default: ".github"
+
+permissions: {}
+
+jobs:
+  pin-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Assert every `uses:` is pinned to a 40-char commit SHA
+        env:
+          SCAN_DIR: ${{ inputs.scan-dir }}
+        run: |
+          set -euo pipefail
+          rc=0
+          # Lines of the form `uses: owner/repo...@ref` (external actions only).
+          while IFS= read -r hit; do
+            file="${hit%%:*}"; rest="${hit#*:}"
+            lineno="${rest%%:*}"; content="${rest#*:}"
+            # Isolate the `uses:` value: drop up to `uses:`, ltrim, keep the first
+            # token only — so inline comments cannot influence the check.
+            value="${content#*uses:}"
+            value="${value#"${value%%[![:space:]]*}"}"
+            value="${value%%[[:space:]]*}"
+            case "$value" in
+              ./*) continue ;;                  # local reusable workflow
+              docker://*@sha256:*) continue ;;  # digest-pinned container action
+            esac
+            ref="${value##*@}"
+            if ! printf '%s' "$ref" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "::error file=${file},line=${lineno}::unpinned action reference: ${value}"
+              rc=1
+            fi
+          done < <(grep -rnE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+@' "$SCAN_DIR" || true)
+          if [ "$rc" -eq 0 ]; then
+            echo "All action references under ${SCAN_DIR} are pinned to a 40-char SHA."
+          fi
+          exit "$rc"

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -1,0 +1,119 @@
+# Centralized reusable workflow: production promotion behind the change-record gate.
+#
+# A production promotion may proceed only when an APPROVED JIRA CCAB ticket exists
+# whose recorded digest matches the digest being promoted. The promotion itself is
+# the referrer-aware `promote.yml` (cosign copy + post-copy verify); the `production`
+# GitHub Environment adds required-reviewer protection on top.
+#
+# Primary sources:
+#   - JIRA Cloud REST API v3 (get issue):
+#     https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get
+#   - GitHub deployment environments + required reviewers:
+#     https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment
+
+name: promote-prod
+
+on:
+  workflow_call:
+    inputs:
+      source-ref:
+        description: "CERT-passed image by digest (registry/repo@sha256:...)"
+        required: true
+        type: string
+      dest-repo:
+        description: "Production ECR repo WITHOUT tag/digest"
+        required: true
+        type: string
+      aws-role-arn:
+        description: "Production ECR IAM role to assume"
+        required: true
+        type: string
+      jira-issue-key:
+        description: "CCAB change ticket key (e.g. CCAB-1234)"
+        required: true
+        type: string
+      jira-digest-field:
+        description: "JIRA custom field id holding the approved build digest (e.g. customfield_10050). When set, the gate hard-asserts the ticket digest equals the promoting digest."
+        required: false
+        type: string
+        default: ""
+      signer-profile-arn:
+        description: "Optional AWS Signer signing-profile ARN passed through to promote.yml for an ECR-native secondary signature"
+        required: false
+        type: string
+        default: ""
+      aws-region:
+        required: false
+        type: string
+        default: "us-east-1"
+    secrets:
+      JIRA_BASE_URL:
+        required: true
+      JIRA_EMAIL:
+        required: true
+      JIRA_API_TOKEN:
+        required: true
+
+permissions: {}
+
+jobs:
+  ccab-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require an APPROVED CCAB ticket whose digest matches
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ISSUE: ${{ inputs.jira-issue-key }}
+          SOURCE_REF: ${{ inputs.source-ref }}
+          DIGEST_FIELD: ${{ inputs.jira-digest-field }}
+        run: |
+          set -euo pipefail
+          case "${SOURCE_REF}" in
+            *@sha256:*) ;;
+            *) echo "::error::source-ref must be digest-pinned (registry/repo@sha256:...), got '${SOURCE_REF}'"; exit 1 ;;
+          esac
+          DIGEST="${SOURCE_REF##*@}"
+          FIELDS="status"
+          [ -n "${DIGEST_FIELD}" ] && FIELDS="status,${DIGEST_FIELD}"
+          RESP="$(curl -fsS -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+            -H 'Accept: application/json' \
+            "${JIRA_BASE_URL}/rest/api/3/issue/${ISSUE}?fields=${FIELDS}")"
+          STATUS="$(echo "$RESP" | jq -r '.fields.status.name')"
+          echo "CCAB ${ISSUE} status: ${STATUS}; promoting digest ${DIGEST}"
+          if [ "$STATUS" != "Approved" ]; then
+            echo "::error::CCAB ticket ${ISSUE} is '${STATUS}', not 'Approved'. Blocking production promotion."
+            exit 1
+          fi
+          # Hard-assert the ticket records the exact digest under change review.
+          if [ -n "${DIGEST_FIELD}" ]; then
+            TICKET_DIGEST="$(echo "$RESP" | jq -r --arg f "${DIGEST_FIELD}" '.fields[$f] // empty' | tr -d '[:space:]')"
+            if [ -z "${TICKET_DIGEST}" ]; then
+              echo "::error::CCAB ticket ${ISSUE} has no digest in field ${DIGEST_FIELD}. Blocking."
+              exit 1
+            fi
+            if [ "${TICKET_DIGEST}" != "${DIGEST}" ]; then
+              echo "::error::CCAB ticket digest ${TICKET_DIGEST} != promoting digest ${DIGEST}. Blocking."
+              exit 1
+            fi
+            echo "CCAB digest match confirmed for ${DIGEST}."
+          else
+            echo "::warning::No jira-digest-field configured; set it to enforce ticket<->digest equality (status-only gate in effect)."
+          fi
+
+  promote:
+    needs: ccab-gate
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+      attestations: read
+    uses: ./.github/workflows/promote.yml
+    with:
+      source-ref: ${{ inputs.source-ref }}
+      dest-repo: ${{ inputs.dest-repo }}
+      target-env: prod
+      aws-role-arn: ${{ inputs.aws-role-arn }}
+      aws-region: ${{ inputs.aws-region }}
+      signer-profile-arn: ${{ inputs.signer-profile-arn }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,140 @@
+# Centralized reusable workflow: referrer-aware promotion between registries.
+#
+# Promotes an immutable digest from a source registry (e.g. GHCR) to a destination
+# (e.g. ECR per environment) using `cosign copy`, which carries the signature and
+# all attestations (SLSA provenance, SBOM, vuln) as OCI referrers. This is the
+# deliberate replacement for `crane cp`, which copies only the image manifest and
+# orphans every referrer (breaking the promotion invariant).
+#
+# A post-copy verification job re-verifies the attestations at the destination and
+# fails the promotion if they do not re-verify.
+#
+# Primary sources:
+#   - cosign copy (carries sig/att/sbom referrers): https://docs.sigstore.dev/cosign/signing/copy/
+#   - OCI referrers / reference types:              https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+#   - AWS ECR + Sigstore referrers:                 https://docs.aws.amazon.com/AmazonECR/latest/userguide/referrers-api.html
+
+name: promote
+
+on:
+  workflow_call:
+    inputs:
+      source-ref:
+        description: "Source image by digest (registry/repo@sha256:...)"
+        required: true
+        type: string
+      dest-repo:
+        description: "Destination repository WITHOUT tag/digest (e.g. <acct>.dkr.ecr.us-east-1.amazonaws.com/app)"
+        required: true
+        type: string
+      target-env:
+        description: "Environment label this promotion targets (int|cert|prod)"
+        required: true
+        type: string
+      aws-role-arn:
+        description: "IAM role to assume for the destination ECR registry"
+        required: true
+        type: string
+      aws-region:
+        required: false
+        type: string
+        default: "us-east-1"
+      signer-profile-arn:
+        description: "Optional AWS Signer signing-profile ARN; when set, add an ECR-native Notation secondary signature on the promoted digest"
+        required: false
+        type: string
+        default: ""
+
+permissions: {}
+
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target-env }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    outputs:
+      dest-ref: ${{ steps.compute.outputs.dest-ref }}
+    steps:
+      - name: Compute destination ref (digest preserved => byte-identical)
+        id: compute
+        run: |
+          set -euo pipefail
+          case "${SOURCE_REF}" in
+            *@sha256:*) ;;
+            *) echo "::error::source-ref must be digest-pinned (registry/repo@sha256:...), got '${SOURCE_REF}'"; exit 1 ;;
+          esac
+          DIGEST="${SOURCE_REF##*@}"
+          echo "dest-ref=${DEST_REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+        env:
+          SOURCE_REF: ${{ inputs.source-ref }}
+          DEST_REPO: ${{ inputs.dest-repo }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+      - name: Login to ECR (destination)
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419  # v2.1.5
+      - name: Login to GHCR (source)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          cosign-release: v3.0.6
+      - name: Referrer-aware copy (image + sig + attestations)
+        env:
+          SOURCE_REF: ${{ inputs.source-ref }}
+          DEST_REF: ${{ steps.compute.outputs.dest-ref }}
+        run: cosign copy -f "${SOURCE_REF}" "${DEST_REF}"
+
+      # OPTIONAL secondary, ECR-native signature via AWS Signer + Notation.
+      # Runs only when `signer-profile-arn` is supplied (the signing profile is
+      # environment-specific). Installer + sign commands per AWS Signer docs:
+      #   https://docs.aws.amazon.com/signer/latest/developerguide/image-signing-prerequisites.html
+      #   https://docs.aws.amazon.com/signer/latest/developerguide/image-signing-steps.html
+      - name: AWS Signer / Notation secondary signature (ECR-native)
+        if: ${{ inputs.signer-profile-arn != '' }}
+        env:
+          DEST_REF: ${{ steps.compute.outputs.dest-ref }}
+          DEST_REPO: ${{ inputs.dest-repo }}
+          PROFILE_ARN: ${{ inputs.signer-profile-arn }}
+          AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          # AWS-published installer (HTTPS from the AWS Signer distribution endpoint):
+          # Notation client + com.amazonaws.signer.notation.plugin
+          curl -fsSL -o "${tmp}/aws-signer-notation-cli_amd64.deb" \
+            https://d2hvyiie56hcat.cloudfront.net/linux/amd64/installer/deb/latest/aws-signer-notation-cli_amd64.deb
+          sudo dpkg -i -E "${tmp}/aws-signer-notation-cli_amd64.deb"
+          notation version
+          notation plugin ls
+          # Authenticate Notation to the destination ECR registry
+          REGISTRY="${DEST_REPO%%/*}"
+          aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" \
+            | notation login --username AWS --password-stdin "${REGISTRY}"
+          # Sign the promoted digest with the AWS Signer profile
+          notation sign "${DEST_REF}" \
+            --plugin "com.amazonaws.signer.notation.plugin" \
+            --id "${PROFILE_ARN}"
+
+  verify:
+    needs: copy
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+      attestations: read
+    uses: ./.github/workflows/verify-attestation.yml
+    with:
+      image-ref: ${{ needs.copy.outputs.dest-ref }}
+      attestation-repo: ${{ github.repository }}
+      aws-role-arn: ${{ inputs.aws-role-arn }}
+      aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/sbom-and-scan.yml
+++ b/.github/workflows/sbom-and-scan.yml
@@ -1,0 +1,115 @@
+# Centralized reusable workflow: standardized SBOM (CycloneDX primary + SPDX export)
+# and Grype vulnerability scan for an image by digest.
+#
+# Produces sbom.cdx.json, sbom.spdx.json, and grype.json as build artifacts. The
+# isolated sign-and-attest workflow already attaches the CycloneDX SBOM + Grype
+# report to the digest as OCI referrers, so `attest` defaults to false here and is
+# only for standalone callers that want the attestations without a full build.
+#
+# Caller MUST pin this workflow by full commit SHA.
+#
+# Primary sources:
+#   - Syft / CycloneDX + SPDX: https://github.com/anchore/syft
+#   - Grype:                   https://github.com/anchore/grype
+#   - cosign attest:           https://docs.sigstore.dev/cosign/signing/other_types/
+
+name: sbom-and-scan
+
+on:
+  workflow_call:
+    inputs:
+      image-ref:
+        description: "Fully-qualified image ref by digest (registry/repo@sha256:...)"
+        required: true
+        type: string
+      attest:
+        description: "Also cosign-attest the CycloneDX SBOM to the digest"
+        required: false
+        type: boolean
+        default: false
+      aws-role-arn:
+        description: "If set, assume this role and log into ECR before reading the image"
+        required: false
+        type: string
+        default: ""
+      aws-region:
+        required: false
+        type: string
+        default: "us-east-1"
+      cosign-version:
+        required: false
+        type: string
+        default: "v3.0.6"
+    outputs:
+      artifact-name:
+        description: "Name of the uploaded artifact holding the CycloneDX + SPDX SBOMs and Grype report"
+        value: "sbom-and-scan"
+
+permissions: {}
+
+jobs:
+  sbom-and-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write       # cosign keyless when attest=true
+      contents: read
+      packages: write       # pull image + push the SBOM attestation referrer to GHCR when attest=true
+    env:
+      IMAGE_REF: ${{ inputs.image-ref }}
+    steps:
+      - name: Configure AWS credentials
+        if: ${{ inputs.aws-role-arn != '' }}
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+      - name: Login to ECR
+        if: ${{ inputs.aws-role-arn != '' }}
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419  # v2.1.5
+
+      - name: Generate CycloneDX SBOM (primary)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          image: ${{ env.IMAGE_REF }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+      - name: Generate SPDX SBOM (export)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          image: ${{ env.IMAGE_REF }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Grype vulnerability scan
+        id: grype
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          image: ${{ env.IMAGE_REF }}
+          output-format: json
+          fail-build: false   # report only; gating happens at promotion/admission
+      - name: Collect Grype report
+        run: cp "${{ steps.grype.outputs.json }}" grype.json
+
+      - name: Upload SBOM + scan artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sbom-and-scan
+          path: |
+            sbom.cdx.json
+            sbom.spdx.json
+            grype.json
+          if-no-files-found: error
+
+      - name: Install cosign
+        if: ${{ inputs.attest }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          cosign-release: ${{ inputs.cosign-version }}
+      - name: Attest CycloneDX SBOM (cosign)
+        if: ${{ inputs.attest }}
+        run: |
+          set -euo pipefail
+          cosign attest --yes \
+            --predicate sbom.cdx.json \
+            --type cyclonedx \
+            "${IMAGE_REF}"

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -1,0 +1,141 @@
+# Centralized reusable workflow: sign + attest a built container image by digest.
+#
+# This workflow is the SLSA Build L3 isolation boundary. Application repos call it
+# via `uses:` and CANNOT modify the signing/attestation steps, so the provenance
+# subject identity is this workflow's `job_workflow_ref`, not the caller's.
+#
+# Primary sources:
+#   - SLSA build provenance / GitHub artifact attestations:
+#     https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
+#   - SLSA Build L3 (isolation requirement):  https://slsa.dev/spec/v1.0/levels#build-l3
+#   - cosign keyless signing (Fulcio + Rekor): https://docs.sigstore.dev/cosign/signing/overview/
+#   - cosign attest (SBOM / vuln predicates):  https://docs.sigstore.dev/cosign/signing/other_types/
+#   - Syft / CycloneDX:                        https://github.com/anchore/syft
+#   - Grype:                                   https://github.com/anchore/grype
+#
+# Caller MUST pin this workflow by full commit SHA, e.g.:
+#   uses: zircote/.github/.github/workflows/sign-and-attest.yml@<SHA>
+
+name: sign-and-attest
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Image repository without tag/digest (e.g. ghcr.io/zircote/app)"
+        required: true
+        type: string
+      image-digest:
+        description: "Immutable image digest pushed by the caller's build (sha256:...)"
+        required: true
+        type: string
+      sbom:
+        description: "Generate + attest a CycloneDX SBOM"
+        required: false
+        type: boolean
+        default: true
+      vuln-scan:
+        description: "Generate + attest a Grype vulnerability report"
+        required: false
+        type: boolean
+        default: true
+      cosign-version:
+        description: "cosign release to install (current stable: v3.0.6)"
+        required: false
+        type: string
+        default: "v3.0.6"
+    outputs:
+      provenance-verified:
+        description: "true when `gh attestation verify` (SLSA provenance) passed in this run"
+        value: ${{ jobs.attest.outputs.provenance-verified }}
+
+permissions: {}
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write       # mint the OIDC token for Sigstore (keyless)
+      attestations: write   # persist GitHub artifact attestation (SLSA provenance)
+      packages: write       # push referrers (sig/att/sbom) to GHCR
+      contents: read
+    outputs:
+      provenance-verified: ${{ steps.verify-prov.outputs.verified }}
+    env:
+      IMAGE_REF: "${{ inputs.image-name }}@${{ inputs.image-digest }}"
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          cosign-release: ${{ inputs.cosign-version }}
+
+      # GHCR's data plane accepts only the workflow's own GITHUB_TOKEN or a
+      # PAT — GitHub App installation tokens are rejected (resource-hiding
+      # 404s; see actions/attest-build-provenance#73 and the container
+      # registry auth docs). One GITHUB_TOKEN login covers the provenance
+      # referrer push and every cosign push below.
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- SLSA Build L3 provenance (GitHub artifact attestation, pushed as OCI referrer) ---
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-name: ${{ inputs.image-name }}
+          subject-digest: ${{ inputs.image-digest }}
+          push-to-registry: true
+
+      # --- Keyless signature over the image digest ---
+      - name: cosign sign (keyless)
+        run: cosign sign --yes "${IMAGE_REF}"
+
+      # --- CycloneDX SBOM, attested as an OCI referrer ---
+      - name: Generate CycloneDX SBOM
+        if: ${{ inputs.sbom }}
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          image: ${{ env.IMAGE_REF }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+      - name: Attest SBOM (cosign)
+        if: ${{ inputs.sbom }}
+        run: |
+          cosign attest --yes \
+            --predicate sbom.cdx.json \
+            --type cyclonedx \
+            "${IMAGE_REF}"
+
+      # --- Grype vulnerability scan, attested as an OCI referrer ---
+      - name: Grype vulnerability scan
+        if: ${{ inputs.vuln-scan }}
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        id: grype
+        with:
+          image: ${{ env.IMAGE_REF }}
+          output-format: json
+          fail-build: false   # attest the result; gating happens at promotion/admission
+      - name: Attest vulnerability report (cosign)
+        if: ${{ inputs.vuln-scan }}
+        run: |
+          cosign attest --yes \
+            --predicate "${{ steps.grype.outputs.json }}" \
+            --type "https://in-toto.io/attestation/vulns/v0.1" \
+            "${IMAGE_REF}"
+
+      # --- Self-verify L3 provenance so the loop is closed before any promotion ---
+      - name: Verify SLSA L3 provenance
+        id: verify-prov
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # --repo asserts the source repository (the caller run); the cert
+          # SAN under SLSA L3 is THIS central workflow, asserted separately.
+          gh attestation verify "oci://${IMAGE_REF}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "zircote/.github/.github/workflows/sign-and-attest.yml" \
+            --predicate-type "https://slsa.dev/provenance/v1"
+          echo "verified=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -1,0 +1,115 @@
+# Centralized reusable workflow: verify a digest's signature + attestations.
+#
+# Fail-closed gate reused by promote.yml (between registry hops) and callable
+# before any deploy. Pins the expected signing identity to this org's centralized
+# sign-and-attest workflow so a signature from any other identity is rejected.
+#
+# Primary sources:
+#   - cosign verify / verify-attestation:
+#     https://docs.sigstore.dev/cosign/verifying/verify/
+#   - gh attestation verify:
+#     https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline
+
+name: verify-attestation
+
+on:
+  workflow_call:
+    inputs:
+      image-ref:
+        description: "Fully-qualified image ref by digest (registry/repo@sha256:...)"
+        required: true
+        type: string
+      attestation-repo:
+        description: "owner/repo that produced the attestation (for gh attestation verify)"
+        required: true
+        type: string
+      certificate-identity-regexp:
+        description: "Expected Fulcio cert identity (the centralized signer workflow)"
+        required: false
+        type: string
+        default: "^https://github.com/zircote/\\.github/\\.github/workflows/sign-and-attest\\.yml@.*$"
+      certificate-oidc-issuer:
+        required: false
+        type: string
+        default: "https://token.actions.githubusercontent.com"
+      signer-workflow:
+        description: "Signer workflow for gh attestation verify (owner/repo/path form)"
+        required: false
+        type: string
+        default: "zircote/.github/.github/workflows/sign-and-attest.yml"
+      require-sbom:
+        required: false
+        type: boolean
+        default: true
+      aws-role-arn:
+        description: "If set, assume this role and log into ECR before verifying"
+        required: false
+        type: string
+        default: ""
+      aws-region:
+        required: false
+        type: string
+        default: "us-east-1"
+
+permissions: {}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+      attestations: read
+    steps:
+      - name: Configure AWS credentials
+        if: ${{ inputs.aws-role-arn != '' }}
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+      - name: Login to ECR
+        if: ${{ inputs.aws-role-arn != '' }}
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419  # v2.1.5
+      - name: Log in to GHCR
+        if: ${{ startsWith(inputs.image-ref, 'ghcr.io/') }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          cosign-release: v3.0.6
+      - name: Verify image signature (keyless identity pinned)
+        env:
+          IMAGE_REF: ${{ inputs.image-ref }}
+          CERT_ID_REGEXP: ${{ inputs.certificate-identity-regexp }}
+          CERT_OIDC_ISSUER: ${{ inputs.certificate-oidc-issuer }}
+        run: |
+          cosign verify "${IMAGE_REF}" \
+            --certificate-identity-regexp "${CERT_ID_REGEXP}" \
+            --certificate-oidc-issuer "${CERT_OIDC_ISSUER}"
+      - name: Verify SLSA provenance (GitHub artifact attestation, signer pinned)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REF: ${{ inputs.image-ref }}
+          ATTESTATION_REPO: ${{ inputs.attestation-repo }}
+          SIGNER_WORKFLOW: ${{ inputs.signer-workflow }}
+        run: |
+          gh attestation verify "oci://${IMAGE_REF}" \
+            --repo "${ATTESTATION_REPO}" \
+            --signer-workflow "${SIGNER_WORKFLOW}" \
+            --predicate-type "https://slsa.dev/provenance/v1"
+      - name: Verify SBOM attestation
+        if: ${{ inputs.require-sbom }}
+        env:
+          IMAGE_REF: ${{ inputs.image-ref }}
+          CERT_ID_REGEXP: ${{ inputs.certificate-identity-regexp }}
+          CERT_OIDC_ISSUER: ${{ inputs.certificate-oidc-issuer }}
+        run: |
+          cosign verify-attestation "${IMAGE_REF}" \
+            --type cyclonedx \
+            --certificate-identity-regexp "${CERT_ID_REGEXP}" \
+            --certificate-oidc-issuer "${CERT_OIDC_ISSUER}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Attested delivery architecture** — nine centralized reusable workflows constituted from `HMH-ProdOps/.github@8f3b4d41a9aeedb430bd575020170ce0641dbd95` and parameterized for zircote: `build-attest.yml`, `sign-and-attest.yml` (SLSA Build L3 signing boundary), `verify-attestation.yml` (fail-closed gate), `promote.yml`, `promote-prod.yml`, `sbom-and-scan.yml`, `dora-emit.yml`, `pin-check.yml`, `mirror-images.yml`
+- SECURITY.md "Verifying Release Artifacts" section with the full workstation verification command set (`gh attestation verify --signer-workflow`, `cosign verify`, SBOM/vuln attestation checks)
 - **Stale Health Check workflow** (`stale-health-check.md`): weekly scan for stale issues (>30d), abandoned PRs (>7d), failing CI, and README staleness across all zircote repos (tracker: `stlhlt01`)
 - **Dependency Ecosystem workflow** (`dependency-ecosystem.md`): weekly cross-repo dependency intelligence — Dependabot PR audit, version consistency, coverage gaps, and health scoring (tracker: `depeco01`)
 - **Agent Health Monitor workflow** (`agent-health-monitor.md`): daily meta-monitoring of all gh-aw workflows for consecutive failures, missed schedules, and timeouts (tracker: `agenthm01`)
 - **Generic compile script** (`scripts/compile-gh-aw.sh`): parameterized compile + patch for any gh-aw workflow, replacing hardcoded org-monitor references
 - Three new automation labels: `stale-health`, `dep-ecosystem`, `agent-health`
+
+### Fixed
+- `dependabot-automerge.yml` called the reusable auto-merge workflow at the mutable `@main` ref; now uses the local-path form (same-commit, exempt from pin-check)
 
 ### Changed
 - `scripts/compile-org-monitor.sh` is now a thin wrapper delegating to `compile-gh-aw.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,37 @@ Instructions and patterns...
 | `reusable-security.yml` | Security scanning | `scan-secrets`, `scan-dependencies` |
 | `reusable-docs.yml` | Documentation deployment | `framework`, `deploy-to-pages` |
 
+## Attested Delivery (Supply-Chain) Workflows
+
+Centralized reusable workflows implementing the attested release architecture:
+signed, SLSA-attested, fail-closed-verified releases. Constituted from
+`HMH-ProdOps/.github@8f3b4d41a9aeedb430bd575020170ce0641dbd95` and
+parameterized for zircote. Signing runs in `sign-and-attest.yml` — the SLSA
+Build L3 boundary the calling repo cannot modify; the Fulcio certificate SAN is
+this central workflow, while the caller is recorded as the source repository.
+
+| Workflow | Role | Key Inputs |
+|----------|------|------------|
+| `build-attest.yml` | Build → push by digest → sign/attest → self-verify (single entry point) | `image-name`, `context`, `dockerfile` |
+| `sign-and-attest.yml` | The L3 signing boundary: SLSA provenance + cosign keyless signature + CycloneDX SBOM + vuln report as OCI referrers, then self-verify | `image-name`, `image-digest` |
+| `verify-attestation.yml` | Fail-closed verification gate before any publish/deploy | `image-ref`, `attestation-repo` |
+| `promote.yml` | Referrer-carrying `cosign copy` between registries + post-copy re-verify | `source-ref`, `dest-repo`, `target-env` |
+| `promote-prod.yml` | `promote.yml` behind the change-record gate | + `jira-issue-key`, `jira-digest-field` |
+| `sbom-and-scan.yml` | Standalone SBOM (CycloneDX + SPDX) + Grype scan | `image-ref` |
+| `dora-emit.yml` | DORA deployment events (call with `if: always()`) | `image-digest` |
+| `pin-check.yml` | Fails on the first `uses:` not pinned to a full 40-char SHA | `scan-dir` |
+| `mirror-images.yml` | Controlled ingress: mirror pinned upstream images into `ghcr.io/zircote/mirror/*` | dispatch/weekly |
+
+Caller rules:
+
+- Pin every `uses:` of these workflows to the full 40-char commit SHA of this
+  repo; Dependabot's `github-actions` ecosystem keeps pins current.
+- Publication/promotion jobs must `needs:` the verify job — fail closed.
+- Verification commands for consumers live in `SECURITY.md` ("Verifying
+  Release Artifacts"). `gh attestation verify` requires **both** `--repo` and
+  `--signer-workflow zircote/.github/.github/workflows/sign-and-attest.yml`
+  (`--repo` alone fails under SLSA L3 — the SAN is the central signer).
+
 ## Available Composite Actions
 
 | Action | Purpose |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,3 +36,41 @@ We follow coordinated disclosure. We ask that you:
 ## Recognition
 
 We appreciate the efforts of security researchers. Contributors who report valid vulnerabilities will be acknowledged (with permission) in our release notes.
+
+## Verifying Release Artifacts
+
+Repositories onboarded to the attested release architecture sign container images
+through the centralized signer workflow in this repository
+(`zircote/.github/.github/workflows/sign-and-attest.yml`). Each release digest
+carries SLSA provenance, a keyless signature, a CycloneDX SBOM, and a
+vulnerability report as OCI referrers. Verify from any workstation with `gh`
+(authenticated) and `cosign`:
+
+```sh
+# 0. Resolve the digest for a tag
+DIGEST=$(gh api 'users/zircote/packages/container/<name>/versions?per_page=20' \
+  --jq '[.[] | select((.metadata.container.tags // []) | index("<tag>"))][0].name')
+
+# 1. SLSA provenance — --repo asserts where the build ran,
+#    --signer-workflow asserts the central signer (both required)
+gh attestation verify "oci://ghcr.io/zircote/<repo>@${DIGEST}" \
+  --repo zircote/<repo> \
+  --signer-workflow zircote/.github/.github/workflows/sign-and-attest.yml \
+  --predicate-type https://slsa.dev/provenance/v1
+
+# 2. Keyless signature
+cosign verify "ghcr.io/zircote/<repo>@${DIGEST}" \
+  --certificate-identity-regexp '^https://github.com/zircote/\.github/\.github/workflows/sign-and-attest\.yml@.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# 3. SBOM attestation (vuln report: same command with
+#    --type "https://in-toto.io/attestation/vulns/v0.1")
+cosign verify-attestation "ghcr.io/zircote/<repo>@${DIGEST}" \
+  --type cyclonedx \
+  --certificate-identity-regexp '^https://github.com/zircote/\.github/\.github/workflows/sign-and-attest\.yml@.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# 4. Release binaries (attested by the repo's own workflow — no --signer-workflow)
+gh release download <tag> --repo zircote/<repo>
+gh attestation verify <binary> --repo zircote/<repo>
+```


### PR DESCRIPTION
## Summary

Constitutes the attested release architecture under zircote — nine centralized reusable workflows implementing **signed, SLSA-attested, fail-closed-verified releases**, fetched from `HMH-ProdOps/.github@8f3b4d41a9aeedb430bd575020170ce0641dbd95` (develop HEAD) and parameterized for this org (signer identity regexp, `--signer-workflow` defaults, mirror namespace `ghcr.io/zircote/mirror/*`, DORA metric prefix).

| Workflow | Role |
|---|---|
| `build-attest.yml` | build → push by digest → sign/attest → self-verify |
| `sign-and-attest.yml` | SLSA Build L3 signing boundary (provenance + cosign signature + CycloneDX SBOM + vuln report as OCI referrers) |
| `verify-attestation.yml` | fail-closed verification gate |
| `promote.yml` / `promote-prod.yml` | digest promotion (+ change-record gate) |
| `sbom-and-scan.yml` | standalone SBOM + Grype scan |
| `dora-emit.yml` | DORA deployment events |
| `pin-check.yml` | full-SHA action pin enforcement |
| `mirror-images.yml` | controlled upstream image ingress |

Also included:
- **Pin fix**: `dependabot-automerge.yml` referenced its reusable workflow at the mutable `@main`; now the local-path form (same-commit, pin-check exempt).
- **SECURITY.md**: "Verifying Release Artifacts" — the full workstation verification command set.
- **CLAUDE.md** + **CHANGELOG** documentation.

## Validation

- All 9 workflows fetched via the GitHub contents API at the pinned ref and verified byte-identical to a clean clone of the canonical repo before parameterization.
- Zero residual canonical-org strings after parameterization.
- `actionlint` clean on all added/modified workflows.
- Every `uses:` inside the added workflows is pinned to a full 40-char SHA (Dependabot `github-actions` ecosystem already active in this repo keeps them current).

The repo is public, so its reusable workflows are callable from any repo (the Actions access-level setting applies only to private/internal repos — confirmed via API, HTTP 422). A follow-up PR adds the `pin-check` CI caller pinned to this PR's merge SHA, which doubles as the cross-repo resolution gate.