### PR TITLE
ci: add pin-check gate; align workflows with generic templates

### DIFF
--- a/.github/skills/attested-delivery/templates/build-attest.yml
+++ b/.github/skills/attested-delivery/templates/build-attest.yml
@@ -20,7 +20,7 @@ on:
   workflow_call:
     inputs:
       image-name:
-        description: "Image repository without tag/digest (e.g. ghcr.io/__org__/dqo/app)"
+        description: "Image repository without tag/digest (e.g. ghcr.io/__org__/app)"
         required: true
         type: string
       context:

--- a/.github/skills/attested-delivery/templates/dora-emit.yml
+++ b/.github/skills/attested-delivery/templates/dora-emit.yml
@@ -102,14 +102,14 @@ jobs:
 
           # 2) Deployment-frequency count metric
           jq -cn --argjson now "$now" --argjson tags "$tags" \
-            '{series:[{metric:"hmh.dora.deployment", points:[[$now,1]], type:"count", tags:$tags}]}' \
+            '{series:[{metric:"__org__.dora.deployment", points:[[$now,1]], type:"count", tags:$tags}]}' \
             | curl -fsS -X POST "https://api.${DD_SITE}/api/v1/series" \
                 -H "DD-API-KEY: ${DD_API_KEY}" -H 'Content-Type: application/json' -d @- >/dev/null
 
           # 3) Lead-time gauge (only when known)
           if [ "${LEAD_TIME}" != "0" ]; then
             jq -cn --argjson now "$now" --argjson lt "${LEAD_TIME}" --argjson tags "$tags" \
-              '{series:[{metric:"hmh.dora.lead_time_seconds", points:[[$now,$lt]], type:"gauge", tags:$tags}]}' \
+              '{series:[{metric:"__org__.dora.lead_time_seconds", points:[[$now,$lt]], type:"gauge", tags:$tags}]}' \
               | curl -fsS -X POST "https://api.${DD_SITE}/api/v1/series" \
                   -H "DD-API-KEY: ${DD_API_KEY}" -H 'Content-Type: application/json' -d @- >/dev/null
           fi

--- a/.github/skills/attested-delivery/templates/sign-and-attest.yml
+++ b/.github/skills/attested-delivery/templates/sign-and-attest.yml
@@ -22,7 +22,7 @@ on:
   workflow_call:
     inputs:
       image-name:
-        description: "Image repository without tag/digest (e.g. ghcr.io/__org__/dqo/app)"
+        description: "Image repository without tag/digest (e.g. ghcr.io/__org__/app)"
         required: true
         type: string
       image-digest:

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -34,10 +34,10 @@ jobs:
           # (driver-opts: image=...) in consumer repos.
           - source: docker.io/moby/buildkit:buildx-stable-1
             dest: ghcr.io/zircote/mirror/buildkit:buildx-stable-1
-          # Rust builder base (ccab Dockerfile builder stage).
+          # Example: language builder base image.
           - source: docker.io/library/rust:1.96-alpine
             dest: ghcr.io/zircote/mirror/rust:1.96-alpine
-          # Distroless runtime base (ccab Dockerfile runtime stage).
+          # Example: minimal runtime base image.
           - source: gcr.io/distroless/static-debian12:nonroot
             dest: ghcr.io/zircote/mirror/static-debian12:nonroot
     steps:

--- a/.github/workflows/pin-check-ci.yml
+++ b/.github/workflows/pin-check-ci.yml
@@ -1,0 +1,35 @@
+# CI gate: every GitHub Actions `uses:` reference in this repo must be pinned
+# to a full 40-char commit SHA (see CLAUDE.md "Workflow Security Requirements").
+#
+# Calls the central pin-check reusable workflow by full repository path pinned
+# to a commit SHA — the same resolution path consumer repos use, so this run
+# also proves the central workflows resolve cross-repo. Dependabot's
+# github-actions ecosystem keeps the pin current.
+#
+# scan-dir is scoped to the two directories holding real action references;
+# the default (.github) would also match documentation examples inside
+# .github/skills/**/*.md, which are illustrative, not executable.
+
+name: ci
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pin-check:
+    permissions:
+      contents: read
+    uses: zircote/.github/.github/workflows/pin-check.yml@68927d3c0db9484f33e78f7f76d2d1917df9b439
+    with:
+      scan-dir: .github/workflows
+
+  pin-check-actions:
+    permissions:
+      contents: read
+    uses: zircote/.github/.github/workflows/pin-check.yml@68927d3c0db9484f33e78f7f76d2d1917df9b439
+    with:
+      scan-dir: actions

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -1,6 +1,6 @@
 # Centralized reusable workflow: production promotion behind the change-record gate.
 #
-# A production promotion may proceed only when an APPROVED JIRA CCAB ticket exists
+# A production promotion may proceed only when an APPROVED JIRA change-record ticket exists
 # whose recorded digest matches the digest being promoted. The promotion itself is
 # the referrer-aware `promote.yml` (cosign copy + post-copy verify); the `production`
 # GitHub Environment adds required-reviewer protection on top.
@@ -29,7 +29,7 @@ on:
         required: true
         type: string
       jira-issue-key:
-        description: "CCAB change ticket key (e.g. CCAB-1234)"
+        description: "Change-record ticket key (e.g. CHG-1234)"
         required: true
         type: string
       jira-digest-field:
@@ -57,10 +57,10 @@ on:
 permissions: {}
 
 jobs:
-  ccab-gate:
+  change-record-gate:
     runs-on: ubuntu-latest
     steps:
-      - name: Require an APPROVED CCAB ticket whose digest matches
+      - name: Require an APPROVED change-record ticket whose digest matches
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
@@ -81,29 +81,29 @@ jobs:
             -H 'Accept: application/json' \
             "${JIRA_BASE_URL}/rest/api/3/issue/${ISSUE}?fields=${FIELDS}")"
           STATUS="$(echo "$RESP" | jq -r '.fields.status.name')"
-          echo "CCAB ${ISSUE} status: ${STATUS}; promoting digest ${DIGEST}"
+          echo "Change record ${ISSUE} status: ${STATUS}; promoting digest ${DIGEST}"
           if [ "$STATUS" != "Approved" ]; then
-            echo "::error::CCAB ticket ${ISSUE} is '${STATUS}', not 'Approved'. Blocking production promotion."
+            echo "::error::Change-record ticket ${ISSUE} is '${STATUS}', not 'Approved'. Blocking production promotion."
             exit 1
           fi
           # Hard-assert the ticket records the exact digest under change review.
           if [ -n "${DIGEST_FIELD}" ]; then
             TICKET_DIGEST="$(echo "$RESP" | jq -r --arg f "${DIGEST_FIELD}" '.fields[$f] // empty' | tr -d '[:space:]')"
             if [ -z "${TICKET_DIGEST}" ]; then
-              echo "::error::CCAB ticket ${ISSUE} has no digest in field ${DIGEST_FIELD}. Blocking."
+              echo "::error::Change-record ticket ${ISSUE} has no digest in field ${DIGEST_FIELD}. Blocking."
               exit 1
             fi
             if [ "${TICKET_DIGEST}" != "${DIGEST}" ]; then
-              echo "::error::CCAB ticket digest ${TICKET_DIGEST} != promoting digest ${DIGEST}. Blocking."
+              echo "::error::Change-record ticket digest ${TICKET_DIGEST} != promoting digest ${DIGEST}. Blocking."
               exit 1
             fi
-            echo "CCAB digest match confirmed for ${DIGEST}."
+            echo "Change-record digest match confirmed for ${DIGEST}."
           else
             echo "::warning::No jira-digest-field configured; set it to enforce ticket<->digest equality (status-only gate in effect)."
           fi
 
   promote:
-    needs: ccab-gate
+    needs: change-record-gate
     permissions:
       id-token: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Attested delivery architecture** — nine centralized reusable workflows constituted from `HMH-ProdOps/.github@8f3b4d41a9aeedb430bd575020170ce0641dbd95` and parameterized for zircote: `build-attest.yml`, `sign-and-attest.yml` (SLSA Build L3 signing boundary), `verify-attestation.yml` (fail-closed gate), `promote.yml`, `promote-prod.yml`, `sbom-and-scan.yml`, `dora-emit.yml`, `pin-check.yml`, `mirror-images.yml`
 - SECURITY.md "Verifying Release Artifacts" section with the full workstation verification command set (`gh attestation verify --signer-workflow`, `cosign verify`, SBOM/vuln attestation checks)
+- **pin-check CI gate** (`pin-check-ci.yml`): every PR asserts all `uses:` references in `.github/workflows/` and `actions/` are pinned to full 40-char SHAs, calling the central `pin-check.yml` by SHA-pinned cross-repo reference
 - **Stale Health Check workflow** (`stale-health-check.md`): weekly scan for stale issues (>30d), abandoned PRs (>7d), failing CI, and README staleness across all zircote repos (tracker: `stlhlt01`)
 - **Dependency Ecosystem workflow** (`dependency-ecosystem.md`): weekly cross-repo dependency intelligence — Dependabot PR audit, version consistency, coverage gaps, and health scoring (tracker: `depeco01`)
 - **Agent Health Monitor workflow** (`agent-health-monitor.md`): daily meta-monitoring of all gh-aw workflows for consecutive failures, missed schedules, and timeouts (tracker: `agenthm01`)
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `dependabot-automerge.yml` called the reusable auto-merge workflow at the mutable `@main` ref; now uses the local-path form (same-commit, exempt from pin-check)
+- attested-delivery skill templates: `dora-emit.yml` left `hmh.dora.*` metric names unparameterized (now `__org__.dora.*`); `build-attest.yml`/`sign-and-attest.yml` example image carried a `dqo/app` path (now `ghcr.io/__org__/app`)
+- `promote-prod.yml` and `mirror-images.yml` regenerated from the generic templates — removes HMH-specific "CCAB" terminology (now "change-record") and repo-specific comments
 
 ### Changed
 - `scripts/compile-org-monitor.sh` is now a thin wrapper delegating to `compile-gh-aw.sh`


### PR DESCRIPTION
## Summary

- **`pin-check-ci.yml`** — every PR now asserts that all `uses:` references in `.github/workflows/` and `actions/` are pinned to full 40-char commit SHAs, by calling the central `pin-check.yml` via SHA-pinned cross-repo reference (`@68927d3`, the #438 merge commit). This run is also the Phase 1 gate: it exercises the same resolution path consumer repos will use. scan-dir is scoped to the two executable directories because the default (`.github`) would flag documentation examples in `.github/skills/**/*.md`.
- **`promote-prod.yml` / `mirror-images.yml`** regenerated from the generic skill templates — removes HMH-specific CCAB terminology and repo-specific comments.
- **Template placeholder gap fixes** in the skill's canonical templates: `dora-emit.yml` left `hmh.dora.*` metric names unparameterized (→ `__org__.dora.*`); `build-attest.yml`/`sign-and-attest.yml` example image carried a `dqo/app` path (→ `ghcr.io/__org__/app`).

## Validation

- All nine installed workflows verified byte-identical to their `__ORG__`/`__org__`-substituted templates.
- pin-check logic simulated locally against both scan dirs: zero violations.
- `actionlint` clean on all touched workflows.
- The `pin-check / pin-check` and `pin-check-actions / pin-check` checks on this PR are the live proof.