### PR TITLE
docs: remediate all documentation review findings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -181,7 +181,7 @@ public class ResourceService {
 ### Standard Layouts
 
 **Python:**
-```
+```text
 src/package_name/
 tests/
   unit/
@@ -190,7 +190,7 @@ pyproject.toml
 ```
 
 **TypeScript:**
-```
+```text
 src/
 tests/
 package.json
@@ -198,7 +198,7 @@ tsconfig.json
 ```
 
 **Go:**
-```
+```text
 cmd/app/
 internal/
 pkg/
@@ -253,9 +253,9 @@ For language-specific workflows, use the reusable workflows in `.github/workflow
 - `reusable-ci-python.yml`
 - `reusable-ci-typescript.yml`
 - `reusable-ci-go.yml`
-- `reusable-ci-rust.yml`
 - `reusable-release.yml`
 - `reusable-security.yml`
+- `reusable-docs.yml`
 
 ## Common Patterns
 

--- a/.github/prompts/analyze-repo-activity.prompt.md
+++ b/.github/prompts/analyze-repo-activity.prompt.md
@@ -76,7 +76,7 @@ Generate a ranked list with:
 
 ## Usage Example
 
-```
+```text
 Analyze zircote's repositories and identify the top 8 most significant active projects,
 excluding forks and archived repositories. Output should be suitable for profile README.
 ```

--- a/.github/skills/ai-tuning/SKILL.md
+++ b/.github/skills/ai-tuning/SKILL.md
@@ -38,7 +38,7 @@ Provide your existing AI configuration files or describe your project, and this 
 
 ## CLAUDE.md Structure
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -69,11 +69,11 @@ Provide your existing AI configuration files or describe your project, and this 
 
 ## Important Patterns
 [Code examples]
-```
+````
 
 ## copilot-instructions.md Structure
 
-```markdown
+````markdown
 # GitHub Copilot Instructions
 
 ## Project Context
@@ -98,7 +98,7 @@ Provide your existing AI configuration files or describe your project, and this 
 
 ## Commands
 [Quick reference]
-```
+````
 
 ## MCP Configuration
 

--- a/.github/skills/attested-delivery/SKILL.md
+++ b/.github/skills/attested-delivery/SKILL.md
@@ -1,9 +1,39 @@
 ---
 name: attested-delivery
-description: Constitute and materialize the attested release architecture — signed, SLSA-attested, fail-closed-verified releases — in any organization or repository. Use when asked to onboard a repo to attested delivery, implement release signing/SLSA provenance/attestation, set up the attested release architecture in an org, migrate CI to SHA-pinned actions with a required pin check, or verify release attestations.
+description: Constitute and materialize the attested release architecture — signed, SLSA-attested, fail-closed-verified releases — in any organization or repository. USE THIS SKILL when user says "onboard to attested delivery", "set up release signing", "SLSA provenance", "attest releases", "constitute the attested architecture", "pin check", or "verify release attestations".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
 ---
 
 # Attested Delivery — Architect & Onboarding Skill
+
+## Purpose
+
+Constitute and materialize the attested release architecture — signed,
+SLSA-attested, fail-closed-verified releases — in any organization or
+repository, from this skill's self-contained workflow templates.
+
+## Triggers
+
+- "onboard this repo to attested delivery"
+- "set up release signing / SLSA provenance"
+- "constitute the attested architecture in [org]"
+- "migrate CI to SHA-pinned actions with a required pin check"
+- "verify release attestations"
+
+## Usage
+
+Run Phase 0 (Discovery) to detect the operating mode, then follow the phase
+protocol below. Mode B constitutes a new org from `templates/`; Mode A wires
+a consumer repo against an existing central repo. Do not proceed past a
+failing phase gate.
+
+## Architecture Invariant
 
 You are implementing a proven supply-chain architecture. The invariant:
 **an artifact reaches consumers only if it is byte-identical to what was

--- a/.github/skills/content-pipeline/SKILL.md
+++ b/.github/skills/content-pipeline/SKILL.md
@@ -31,7 +31,7 @@ Request content creation by specifying the type (blog, social, video) and topic.
 
 ## Content Directory Structure
 
-```
+```text
 content/
 ├── blog/
 │   ├── drafts/           # Work in progress
@@ -76,7 +76,7 @@ draft: true
 ## Social Media Formats
 
 ### Twitter/X (280 chars)
-```
+```text
 Hook line creating curiosity
 
 Key insight or value prop
@@ -87,7 +87,7 @@ Call to action + link
 ```
 
 ### LinkedIn (3000 chars)
-```
+```text
 Opening hook
 
 Story or context
@@ -102,7 +102,7 @@ Call to action
 ```
 
 ### Thread Structure
-```
+```text
 1/ Hook promising value
 2/ Context setup
 3-8/ Main points (one per tweet)
@@ -133,7 +133,7 @@ Call to action
 
 ## Content Repurposing Flow
 
-```
+```text
 Blog Post (1500+ words)
     ↓
 Twitter Thread (8-12 tweets)

--- a/.github/skills/ecosystem-migration/SKILL.md
+++ b/.github/skills/ecosystem-migration/SKILL.md
@@ -75,7 +75,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       python-version: '3.12'
     secrets: inherit
@@ -105,7 +105,7 @@ Best for: Large projects requiring careful migration
 
 ## Adding AI Integration
 
-```bash
+````bash
 # Create CLAUDE.md
 cat > CLAUDE.md << 'EOF'
 # CLAUDE.md
@@ -133,7 +133,7 @@ cat > .github/copilot-instructions.md << 'EOF'
 ## Code Guidelines
 [Language patterns]
 EOF
-```
+````
 
 ## Converting to Reusable Workflows
 
@@ -145,7 +145,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: pip install ruff && ruff check .
 ```
 
@@ -155,7 +155,7 @@ name: CI
 on: [push]
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
 ```
 
 ## Validation After Migration
@@ -167,7 +167,8 @@ for f in CLAUDE.md .github/copilot-instructions.md; do
 done
 
 # Validate workflows
-./scripts/validate-sha-pinning.sh .github/workflows/
+actionlint .github/workflows/*.yml
+grep -rnE "uses:.*@(main|master|v[0-9])" .github/workflows/ || echo "all pinned"
 
 # Test CI (if possible)
 # Run linting, tests locally

--- a/.github/skills/presentation-generation/SKILL.md
+++ b/.github/skills/presentation-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: presentation-generation
-description: Generate slide deck presentations from prompts. Triggers on "create presentation", "generate slides", "build deck", "presentation about"
+description: Generate slide deck presentations from prompts. USE THIS SKILL when user says "create presentation", "generate slides", "build deck", or "presentation about"
 allowed-tools:
   - Bash
   - Read
@@ -34,7 +34,7 @@ Describe your presentation topic, audience, and desired style. The skill will re
 
 ## Workflow Overview
 
-```
+```text
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │   1. RESEARCH   │────▶│   2. OUTLINE    │────▶│   3. CONTENT    │
 │   (Optional)    │     │   Generation    │     │   Expansion     │
@@ -48,7 +48,7 @@ Describe your presentation topic, audience, and desired style. The skill will re
 
 ## Directory Structure
 
-```
+```text
 docs/presentations/
 ├── templates/
 │   ├── systematic-velocity.py      # Dark, data-focused style
@@ -71,7 +71,7 @@ docs/presentations/
 
 ## Presentation Markdown Format
 
-```markdown
+````markdown
 ---
 title: "Presentation Title"
 subtitle: "Optional Subtitle"
@@ -142,7 +142,7 @@ Right column content
 # Thank You
 
 <!-- cta: text="Get Started" url="https://github.com/zircote/github" -->
-```
+````
 
 ## Research Phase
 

--- a/.github/skills/security-baseline/SKILL.md
+++ b/.github/skills/security-baseline/SKILL.md
@@ -96,7 +96,7 @@ permissions:
   contents: read
 
 steps:
-  - uses: aws-actions/configure-aws-credentials@...
+  - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
     with:
       role-to-assume: arn:aws:iam::123456789:role/github-actions
       aws-region: us-east-1

--- a/.github/skills/template-creation/SKILL.md
+++ b/.github/skills/template-creation/SKILL.md
@@ -32,7 +32,7 @@ Use this skill to create new project templates from scratch or customize existin
 
 Every template MUST include:
 
-```
+```text
 templates/[name]-template/
 ├── README.md                  # Project documentation
 ├── CLAUDE.md                  # Claude Code instructions

--- a/.github/skills/workflow-development/SKILL.md
+++ b/.github/skills/workflow-development/SKILL.md
@@ -62,7 +62,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       python-version: '3.12'
       coverage-threshold: 80
@@ -93,8 +93,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: zircote/.github/actions/setup-python-uv@main
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: zircote/.github/actions/setup-python-uv@2192c47863886d7a867b5042fb08de414f948f49 # main
         with:
           python-version: ${{ inputs.python-version }}
       - run: uv run ruff check .
@@ -127,7 +127,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: astral-sh/setup-uv@v4
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
     - shell: bash
@@ -158,14 +158,11 @@ runs:
 ## Validation
 
 ```bash
-# Validate SHA pinning
-./scripts/validate-sha-pinning.sh .github/workflows/
-
-# Check for unpinned actions
-grep -rn "uses:.*@v[0-9]" .github/workflows/
-
 # Validate workflow structure
-./scripts/validate-workflows.sh .github/workflows/
+actionlint .github/workflows/*.yml
+
+# Check for unpinned actions (the pin-check required CI check enforces this)
+grep -rnE "uses:.*@(main|master|v[0-9])" .github/workflows/
 ```
 
 ## Performance Optimization
@@ -173,7 +170,7 @@ grep -rn "uses:.*@v[0-9]" .github/workflows/
 ### Caching
 
 ```yaml
-- uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f
+- uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.4
   with:
     path: ~/.cache/uv
     key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/update-profile-readme.yml
+++ b/.github/workflows/update-profile-readme.yml
@@ -120,11 +120,13 @@ jobs:
           NEW_REPOS: ${{ needs.analyze-activity.outputs.new-repos-json }}
           DRY_RUN: ${{ inputs.dry-run || 'false' }}
         run: |
+          ARGS=()
+          [[ "$DRY_RUN" == "true" ]] && ARGS+=(--dry-run)
           python scripts/update-profile-readme.py \
             --readme-path profile/README.md \
             --top-repos "$TOP_REPOS" \
             --new-repos "$NEW_REPOS" \
-            $([[ "$DRY_RUN" == "true" ]] && echo "--dry-run")
+            "${ARGS[@]}"
 
       - name: Check for changes
         id: changes
@@ -137,19 +139,37 @@ jobs:
             echo "Changes detected in README"
           fi
 
-      - name: Commit and push changes
+      # Branch protection requires changes to land via pull request — a direct
+      # push to main is rejected (GH006). The App token (not GITHUB_TOKEN) must
+      # create the PR so the pin-check required checks still trigger on it.
+      - name: Generate App token
+        id: app-token
         if: steps.changes.outputs.changed == 'true' && inputs.dry-run != true
+        uses: actions/create-github-app-token@bf559f85448f9380bcfa2899dbdc01eb5b37be3a # v3.0.0
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: zircote
+          repositories: .github
+
+      - name: Open auto-merge PR with changes
+        if: steps.changes.outputs.changed == 'true' && inputs.dry-run != true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          BRANCH="profile-update/${{ github.run_id }}"
+          git config user.name "zircote-org-monitor[bot]"
+          git config user.email "zircote-org-monitor[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add profile/README.md
-          git commit -m "docs(profile): update activity highlights [skip ci]"
-          # Pull with rebase to handle concurrent updates, then push with retry
-          for i in 1 2 3; do
-            git pull --rebase origin main && git push && break
-            echo "Push attempt $i failed, retrying..."
-            sleep 2
-          done
+          git commit -m "docs(profile): update activity highlights"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
+          git push -u origin "$BRANCH"
+          gh pr create --title "docs(profile): update activity highlights" \
+            --body "Automated weekly profile README refresh from \`update-profile-readme.yml\`." \
+            --base main --head "$BRANCH"
+          gh pr merge "$BRANCH" --squash --auto
 
       - name: Generate summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Three new automation labels: `stale-health`, `dep-ecosystem`, `agent-health`
 
 ### Fixed
+- **Profile README automation silently broken**: `update-profile-readme.yml` pushed directly to the protected `main` branch, was rejected (GH006), and the retry loop swallowed the failure — runs reported success while the profile went stale since 2026-03. Now opens an auto-merge PR via the GitHub App token and fails loudly
+- **README examples called nonexistent workflow inputs** (`run-tests`, `run-race-detector`, `scan-secrets`/`scan-dependencies` on reusable-security, `generate-changelog`, composite-action `cache`/`version`/`output-file`) — all examples regenerated from the actual `workflow_call`/action inputs
+- **Documentation taught unpinned `@main`/`@v4` action refs** contradicting the org SHA-pinning policy — all positive examples in README, skills, agents, and presentation docs now pin to full commit SHAs
+- **Broken markdown fence nesting** (3-backtick templates containing 3-backtick code blocks) in copilot-tuner, ecosystem-migrator, ai-tuning, ecosystem-migration, presentation-generation, and presentations README — outer fences now use 4 backticks; this also fixes the phantom broken `assets/diagram.png` image link
+- `.github/copilot-instructions.md` referenced nonexistent `reusable-ci-rust.yml`; agents/skills referenced nonexistent `scripts/validate-sha-pinning.sh`/`validate-workflows.sh` (replaced with actionlint + pin grep)
+- profile/README.md ccpkg link pointed at renamed `zircote/plugin-packaging` (now `zircote/ccpkg`); example presentation author corrected to Robert Allen
+- CONTRIBUTING.md development setup replaced generic boilerplate with this repo's real toolchain (actionlint, compile-gh-aw.sh, pin-check)
+- README links to private template repos now marked private instead of 404ing for visitors; added LICENSE file (MIT) to back the README license claim; ~40 unlabeled code fences given language tags
+- `attested-delivery` skill brought into skill-doc compliance (Purpose/Triggers/Usage sections, allowed-tools frontmatter, trigger-phrase description); profile-maintainer agent aligned to the shared agent structure
 - `dependabot-automerge.yml` called the reusable auto-merge workflow at the mutable `@main` ref; now uses the local-path form (same-commit, exempt from pin-check)
 - attested-delivery skill templates: `dora-emit.yml` left `hmh.dora.*` metric names unparameterized (now `__org__.dora.*`); `build-attest.yml`/`sign-and-attest.yml` example image carried a `dqo/app` path (now `ghcr.io/__org__/app`)
 - `promote-prod.yml` and `mirror-images.yml` regenerated from the generic templates — removes HMH-specific "CCAB" terminology (now "change-record") and repo-specific comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,25 @@ Thank you for your interest in contributing to .github! This document provides g
 
 ## Development Setup
 
+This repository holds GitHub configuration (workflows, composite actions, skills,
+agents) — there is no application build or test suite. The development loop is:
+
 1. Clone your fork:
    ```bash
    git clone https://github.com/<your-username>/.github.git
    cd .github
    ```
-2. Install dependencies (see README for project-specific instructions).
-3. Run the test suite to verify your setup.
+2. Validate workflow changes with [actionlint](https://github.com/rhysd/actionlint):
+   ```bash
+   actionlint .github/workflows/<changed-file>.yml
+   ```
+3. For gh-aw agentic workflows (`.github/workflows/*.md`), compile and patch with:
+   ```bash
+   bash scripts/compile-gh-aw.sh <workflow-name>
+   ```
+   The generated `.lock.yml` files are build artifacts — never edit them directly.
+4. Every `uses:` reference must be pinned to a full 40-char commit SHA; the
+   `pin-check` required CI check enforces this on every pull request.
 
 ## Code Style
 
@@ -43,7 +55,7 @@ Thank you for your interest in contributing to .github! This document provides g
 
 Use clear, descriptive commit messages:
 
-```
+```text
 <type>: <short summary>
 
 <optional body with more detail>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Robert Allen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ This repository provides shared infrastructure across all `zircote/*` repos:
 | Label Definitions      | Standardized issue/PR labels               | `labels.yml`         |
 | Copilot Skills         | AI-assisted development capabilities       | `.github/skills/`    |
 | Autonomous Agents      | Multi-step AI workflow automation          | `agents/`            |
+| Attested Delivery      | Signed, SLSA-attested, verified releases   | `.github/workflows/` |
 
 ## Repository Structure
 
-```
+```text
 .github/
 ├── .github/
 │   ├── workflows/               # Reusable workflows
@@ -28,14 +29,25 @@ This repository provides shared infrastructure across all `zircote/*` repos:
 │   │   ├── reusable-release.yml
 │   │   ├── reusable-security.yml
 │   │   ├── reusable-docs.yml
-│   │   └── sync-labels.yml
+│   │   ├── reusable-presentation.yml
+│   │   ├── reusable-content.yml
+│   │   ├── reusable-dependabot-automerge.yml
+│   │   ├── sync-labels.yml
+│   │   ├── build-attest.yml         # Attested delivery (see CLAUDE.md)
+│   │   ├── sign-and-attest.yml
+│   │   ├── verify-attestation.yml
+│   │   ├── promote.yml / promote-prod.yml
+│   │   ├── sbom-and-scan.yml / pin-check.yml
+│   │   └── mirror-images.yml / dora-emit.yml
 │   ├── skills/                  # Copilot Skills
 │   │   ├── template-creation/
 │   │   ├── workflow-development/
 │   │   ├── security-baseline/
 │   │   ├── content-pipeline/
 │   │   ├── ecosystem-migration/
-│   │   └── ai-tuning/
+│   │   ├── ai-tuning/
+│   │   ├── presentation-generation/
+│   │   └── attested-delivery/
 │   └── copilot-instructions.md
 ├── actions/                     # Composite Actions
 │   ├── setup-python-uv/
@@ -48,7 +60,10 @@ This repository provides shared infrastructure across all `zircote/*` repos:
 │   ├── security-auditor.md
 │   ├── content-strategist.md
 │   ├── ecosystem-migrator.md
-│   └── copilot-tuner.md
+│   ├── copilot-tuner.md
+│   └── profile-maintainer.md
+├── docs/                        # Presentations and assets
+├── scripts/                     # Automation scripts
 ├── profile/
 │   └── README.md
 ├── labels.yml
@@ -61,15 +76,18 @@ This repository provides shared infrastructure across all `zircote/*` repos:
 
 ## Reusable Workflows
 
+All `uses:` references must be pinned to a full 40-char commit SHA (enforced by
+the `pin-check` required check) — never `@main` or version tags. Dependabot's
+`github-actions` ecosystem keeps pins current.
+
 ### Python CI
 
 ```yaml
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       python-version: "3.12"
-      run-tests: true
       coverage-threshold: 80
 ```
 
@@ -78,10 +96,10 @@ jobs:
 ```yaml
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-typescript.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-typescript.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       node-version: "22"
-      run-tests: true
+      coverage-threshold: 80
 ```
 
 ### Go CI
@@ -89,10 +107,10 @@ jobs:
 ```yaml
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-go.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-go.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       go-version: "1.23"
-      run-race-detector: true
+      enable-build: true
 ```
 
 ### Security Scanning
@@ -100,10 +118,10 @@ jobs:
 ```yaml
 jobs:
   security:
-    uses: zircote/.github/.github/workflows/reusable-security.yml@main
+    uses: zircote/.github/.github/workflows/reusable-security.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
-      scan-secrets: true
-      scan-dependencies: true
+      python-audit: true
+      fail-on-vulnerabilities: true
 ```
 
 ### Release Automation
@@ -111,9 +129,10 @@ jobs:
 ```yaml
 jobs:
   release:
-    uses: zircote/.github/.github/workflows/reusable-release.yml@main
+    uses: zircote/.github/.github/workflows/reusable-release.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
-      generate-changelog: true
+      release-type: auto  # or patch, minor, major
+      generate-notes: true
 ```
 
 ### Documentation Deployment
@@ -121,11 +140,20 @@ jobs:
 ```yaml
 jobs:
   docs:
-    uses: zircote/.github/.github/workflows/reusable-docs.yml@main
+    uses: zircote/.github/.github/workflows/reusable-docs.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       framework: astro  # or mkdocs, sphinx, docusaurus
       deploy-to-pages: true
 ```
+
+### Attested Delivery
+
+Centralized supply-chain workflows for signed, SLSA-attested, fail-closed-verified
+releases: `build-attest.yml`, `sign-and-attest.yml`, `verify-attestation.yml`,
+`promote.yml`, `promote-prod.yml`, `sbom-and-scan.yml`, `pin-check.yml`,
+`mirror-images.yml`, `dora-emit.yml`. Caller recipes live in
+[CLAUDE.md](CLAUDE.md); consumer verification commands live in
+[SECURITY.md](SECURITY.md#verifying-release-artifacts).
 
 ---
 
@@ -134,25 +162,25 @@ jobs:
 ### setup-python-uv
 
 ```yaml
-- uses: zircote/.github/actions/setup-python-uv@main
+- uses: zircote/.github/actions/setup-python-uv@2192c47863886d7a867b5042fb08de414f948f49 # main
   with:
     python-version: "3.12"
-    cache: true
+    install-dependencies: true
 ```
 
 ### setup-node-pnpm
 
 ```yaml
-- uses: zircote/.github/actions/setup-node-pnpm@main
+- uses: zircote/.github/actions/setup-node-pnpm@2192c47863886d7a867b5042fb08de414f948f49 # main
   with:
     node-version: "22"
-    cache: true
+    install-dependencies: true
 ```
 
 ### security-scan
 
 ```yaml
-- uses: zircote/.github/actions/security-scan@main
+- uses: zircote/.github/actions/security-scan@2192c47863886d7a867b5042fb08de414f948f49 # main
   with:
     scan-secrets: true
     scan-dependencies: true
@@ -162,10 +190,10 @@ jobs:
 ### release-notes
 
 ```yaml
-- uses: zircote/.github/actions/release-notes@main
+- uses: zircote/.github/actions/release-notes@2192c47863886d7a867b5042fb08de414f948f49 # main
   with:
-    version: ${{ github.ref_name }}
-    output-file: CHANGELOG.md
+    from-tag: v1.0.0
+    include-contributors: true
 ```
 
 ---
@@ -221,14 +249,14 @@ gh workflow run sync-labels.yml -f repo=zircote/my-repo
 
 ### Project Templates
 
-| Template                                                           | Stack                           |
-| ------------------------------------------------------------------ | ------------------------------- |
-| [python-template](https://github.com/zircote/python-template)      | Python 3.12+, uv, ruff, pyright |
-| [typescript-template](https://github.com/zircote/typescript-template) | Node 22, pnpm, ESLint 9, Vitest |
-| [go-template](https://github.com/zircote/go-template)              | Go 1.23+, golangci-lint         |
-| [rust-template](https://github.com/zircote/rust-template)          | Stable, clippy, cargo-deny      |
-| [java-template](https://github.com/zircote/java-template)          | Java 21, Gradle, JUnit 5        |
-| [docs-site-template](https://github.com/zircote/docs-site-template)| Astro, Starlight, MDX           |
+| Template                                                   | Stack                           |
+| ----------------------------------------------------------- | ------------------------------- |
+| `python-template` (private)                                 | Python 3.12+, uv, ruff, pyright |
+| `typescript-template` (private)                             | Node 22, pnpm, ESLint 9, Vitest |
+| `go-template` (private)                                     | Go 1.23+, golangci-lint         |
+| [rust-template](https://github.com/zircote/rust-template)   | Stable, clippy, cargo-deny      |
+| `java-template` (private)                                   | Java 21, Gradle, JUnit 5        |
+| `docs-site-template` (private)                              | Astro, Starlight, MDX           |
 
 ### Tools & Plugins
 
@@ -256,12 +284,13 @@ Recent updates to this organization configuration:
 
 | Date | Change | Impact |
 |------|--------|--------|
+| 2026-06 | Attested delivery architecture | Signed, SLSA-attested, fail-closed-verified releases + pin-check CI gate |
 | 2026-01 | Added presentation-generation skill | New slide deck generation from markdown |
 | 2026-01 | Added profile-maintainer agent | Automated profile README updates |
 | 2025-12 | Initial ecosystem setup | Reusable workflows, templates, AI integration |
 
-For detailed history, see [commit log](https://github.com/zircote/.github/commits/main).
+For detailed history, see the [CHANGELOG](CHANGELOG.md) and [commit log](https://github.com/zircote/.github/commits/main).
 
 ## License
 
-MIT License - See individual files for specific licensing.
+[MIT License](LICENSE).

--- a/agents/content-strategist.md
+++ b/agents/content-strategist.md
@@ -25,7 +25,7 @@ You are an expert in content strategy and pipeline management. You help users pl
 
 ## Content Pipeline Structure
 
-```
+```text
 content/
 ├── blog/
 │   ├── drafts/           # Work in progress
@@ -127,7 +127,7 @@ image_alt: "Descriptive alt text"
 ### Social Media Adaptations
 
 **Twitter/X (280 chars):**
-```
+```text
 Hook line that creates curiosity
 
 Key insight or value proposition
@@ -138,7 +138,7 @@ Call to action + link
 ```
 
 **LinkedIn (3000 chars):**
-```
+```text
 Opening hook that resonates professionally
 
 Story or context that builds connection
@@ -154,7 +154,7 @@ Call to action
 ```
 
 **Thread Structure:**
-```
+```text
 1/ Hook that promises value
 
 2/ Context and setup

--- a/agents/copilot-tuner.md
+++ b/agents/copilot-tuner.md
@@ -35,7 +35,7 @@ You are an expert in optimizing AI assistant configurations for development work
 
 ### copilot-instructions.md Structure
 
-```markdown
+````markdown
 # GitHub Copilot Instructions
 
 ## Project Context
@@ -78,11 +78,11 @@ You are an expert in optimizing AI assistant configurations for development work
 - Source: `src/`
 - Tests: `tests/`
 - Config: `[config files]`
-```
+````
 
 ### CLAUDE.md Structure
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -129,7 +129,7 @@ You are an expert in optimizing AI assistant configurations for development work
 
 ## Important Patterns
 [Code examples of common patterns]
-```
+````
 
 ## Pattern Library Development
 
@@ -177,7 +177,7 @@ async function fetchData<T>(url: string): Promise<Result<T, FetchError>> {
 
 ### Anti-Pattern Documentation
 
-```markdown
+````markdown
 ### Avoid: Silent Error Swallowing
 
 ```python
@@ -194,7 +194,7 @@ except SpecificError as e:
     logger.warning("Operation failed: %s", e)
     result = fallback_value
 ```
-```
+````
 
 ## MCP Configuration
 
@@ -270,7 +270,7 @@ Testing is done with pytest."
 
 ### 2. Example-Driven Instructions
 
-```markdown
+````markdown
 # Instead of:
 "Use type annotations on all functions."
 
@@ -279,7 +279,7 @@ Testing is done with pytest."
 ```python
 def process(items: list[str], limit: int = 10) -> dict[str, int]: ...
 ```"
-```
+````
 
 ### 3. Constraint Specification
 

--- a/agents/ecosystem-migrator.md
+++ b/agents/ecosystem-migrator.md
@@ -64,7 +64,7 @@ echo "=== AI Integration ==="
 
 **Workflow Overview:**
 
-```
+```text
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
 │ Assess      │────▶│ Plan        │────▶│ Migrate     │────▶│ Validate    │
 │ Repository  │     │ Strategy    │     │ Components  │     │ & Rollback  │
@@ -103,7 +103,8 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    # Always pin to a full commit SHA — never @main (enforced by pin-check)
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       python-version: '3.12'
       coverage-threshold: 80
@@ -137,7 +138,7 @@ Best for: Large projects requiring careful migration
 
 ### Adding CLAUDE.md
 
-```bash
+````bash
 # Generate CLAUDE.md based on project analysis
 cat > CLAUDE.md << 'EOF'
 # CLAUDE.md
@@ -162,7 +163,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 [Document key patterns and decisions]
 EOF
-```
+````
 
 ### Adding Copilot Instructions
 
@@ -197,8 +198,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - run: pip install ruff
@@ -207,8 +208,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - run: pip install pytest
@@ -222,7 +223,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       python-version: '3.12'
 ```
@@ -253,8 +254,9 @@ for f in CLAUDE.md .github/copilot-instructions.md .github/workflows/ci.yml; do
 done
 
 # Validate workflows
-./scripts/validate-sha-pinning.sh .github/workflows/
-./scripts/validate-workflows.sh .github/workflows/
+actionlint .github/workflows/*.yml
+# Assert every action reference is pinned to a full 40-char SHA
+grep -rnE 'uses:.*@(main|master|v[0-9])' .github/workflows/ && echo "UNPINNED REFS FOUND" || echo "all pinned"
 
 # Run CI locally (if possible)
 # act push --job lint

--- a/agents/profile-maintainer.md
+++ b/agents/profile-maintainer.md
@@ -13,24 +13,14 @@ model: sonnet
 
 # Profile Maintainer Agent
 
-> Specialized agent for maintaining and updating GitHub profile README with activity insights.
-
-## Role
-
 You are a profile maintenance specialist that analyzes GitHub activity and generates compelling, accurate profile content. You understand developer audiences and create content that highlights meaningful contributions without exaggeration.
 
-## Capabilities
+## Core Competencies
 
 1. **Activity Analysis** - Fetch and analyze GitHub events, commits, and repository metrics
 2. **Content Generation** - Create markdown sections for profile READMEs
 3. **Metric Calculation** - Weight and rank repositories by significance
 4. **Format Compliance** - Generate content that fits within marker comments
-
-## Tools Available
-
-- `Bash` - Execute GitHub CLI commands for data fetching
-- `Read`, `Write`, `Edit` - Modify files in the repository
-- `Glob`, `Grep` - Search and find content
 
 ## Activation Triggers
 
@@ -42,7 +32,7 @@ Use this agent when:
 
 ## Workflow
 
-```
+```text
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │  1. COLLECT     │────▶│  2. SCORE       │────▶│  3. GENERATE    │
 │  GitHub Data    │     │  Repositories   │     │  Markdown       │
@@ -74,7 +64,7 @@ gh api users/zircote/events/public \
 
 Calculate significance score for each repository:
 
-```
+```text
 Score = (
     recent_commits / 50 * 0.40 +    # Commit velocity
     stars / 1000 * 0.20 +            # Community validation
@@ -130,7 +120,7 @@ Always preserve the marker comments when updating:
 
 ## Example Invocation
 
-```
+```text
 @profile-maintainer Update the profile README with current activity data.
 Focus on repositories with commits in the last 90 days.
 Highlight any new repositories created this quarter.
@@ -149,3 +139,11 @@ Highlight any new repositories created this quarter.
 - `scripts/update-profile-readme.py` - README update script
 - `.github/workflows/update-profile-readme.yml` - Automated workflow
 - `.github/prompts/profile-readme-update.prompt.md` - Copilot prompt template
+
+## When Assisting Users
+
+1. **Collect real data first**: Never generate activity claims without fetching them
+2. **Score transparently**: Apply the documented algorithm, not intuition
+3. **Preserve markers**: Updates must stay within the marker comments
+4. **Validate before committing**: Check URLs, markdown safety, and recency claims
+5. **Report honestly**: Skip incomplete data rather than hallucinate

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -122,7 +122,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # Checks out untrusted code!
 

--- a/agents/template-architect.md
+++ b/agents/template-architect.md
@@ -107,7 +107,7 @@ jobs:
 
 **Workflow Overview:**
 
-```
+```text
 ┌─────────────┐     ┌──────────────┐     ┌─────────────┐
 │ Identify    │────▶│ Copy &       │────▶│ Customize   │
 │ Base        │     │ Rename       │     │ Tooling     │

--- a/agents/workflow-engineer.md
+++ b/agents/workflow-engineer.md
@@ -17,7 +17,7 @@ You are an expert in GitHub Actions, specializing in creating secure, efficient,
 
 **Workflow Overview:**
 
-```
+```text
 ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
 │ Understand   │────▶│ Design with  │────▶│ Implement    │
 │ Requirements │     │ Security     │     │ & Test       │
@@ -75,7 +75,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@main
+    uses: zircote/.github/.github/workflows/reusable-ci-python.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       python-version: '3.12'
       coverage-threshold: 80
@@ -110,7 +110,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # ... implementation
 ```
 
@@ -140,7 +140,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
 

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -62,7 +62,7 @@ White with vibrant gradients. High-contrast with strong CTAs.
 
 ## Markdown Format
 
-```markdown
+````markdown
 ---
 title: "Presentation Title"
 subtitle: "Optional Subtitle"
@@ -125,11 +125,11 @@ def hello():
 # Call to Action
 
 <!-- cta: text="Get Started" url="https://example.com" -->
-```
+````
 
 ## Directory Structure
 
-```
+```text
 docs/presentations/
 ├── generate.py          # Main generation script - handles PDF, PPTX, HTML output
 ├── README.md            # This documentation file
@@ -164,7 +164,7 @@ When you generate a presentation from markdown, you get:
 
 ### Sample Generated Slide (Systematic Velocity Style)
 
-```
+```text
 ┌─────────────────────────────────────────────┐
 │  ████████████████████████████████████████   │  <- #1A1A1A background
 │                                             │
@@ -187,7 +187,7 @@ When you generate a presentation from markdown, you get:
 ```yaml
 jobs:
   generate:
-    uses: zircote/.github/.github/workflows/reusable-presentation.yml@main
+    uses: zircote/.github/.github/workflows/reusable-presentation.yml@2192c47863886d7a867b5042fb08de414f948f49 # main
     with:
       source: 'docs/presentations/drafts/my-deck.md'
       formats: 'pdf,html,pptx'

--- a/docs/presentations/drafts/example-presentation.md
+++ b/docs/presentations/drafts/example-presentation.md
@@ -1,7 +1,7 @@
 ---
 title: "Personal GitHub Ecosystem"
 subtitle: "Enterprise-Grade DevOps for Personal Projects"
-author: "Allen Robel"
+author: "Robert Allen"
 date: 2025-12-29
 style: systematic-velocity
 format:

--- a/profile/README.md
+++ b/profile/README.md
@@ -50,7 +50,7 @@ MIF solves vendor lock-in, data ownership, and future-proofing for AI memory. Ke
 - **W3C PROV provenance** and **JSON Schema validation**
 - **Migration guides** from Mem0, Zep, Letta, Subcog, and Basic Memory
 
-**Status:** v0.1.0-draft &bull; [Specification](https://mif-spec.dev/SPECIFICATION) &bull; [GitHub](https://github.com/zircote/MIF)
+**Status:** v0.1.0-draft &bull; [Specification](https://mif-spec.dev/specification/overview/) &bull; [GitHub](https://github.com/zircote/MIF)
 
 ### [ccpkg](https://ccpkg.dev) — Portable Packaging for AI Coding Extensions
 
@@ -67,7 +67,7 @@ One file, one install, zero post-install steps. Key features:
 - **Decentralized registries** — JSON files hostable on GitHub Pages, S3, or any static server
 - **Built on open standards** — Agent Skills, MCP, LSP, SemVer, JSON Schema
 
-**Status:** Draft (2026-02-14) &bull; [Specification](https://ccpkg.dev/spec/specification.html) &bull; [GitHub](https://github.com/zircote/plugin-packaging)
+**Status:** Draft (2026-02-14) &bull; [Specification](https://ccpkg.dev/specification/overview/) &bull; [GitHub](https://github.com/zircote/ccpkg)
 
 ---
 


### PR DESCRIPTION
## Summary

Remediates every finding from the documentation quality review (2 critical, 7 major, 8 minor):

- **Broken examples fixed**: README workflow/action examples regenerated from the real `workflow_call`/`action.yml` inputs (the old ones failed at workflow startup if copied); phantom `reusable-ci-rust.yml` reference removed.
- **Profile automation repaired**: `update-profile-readme.yml` was silently failing for 3 months — direct pushes to protected main were GH006-rejected and the retry loop swallowed the error. Now opens an auto-merge PR via the GitHub App token with `set -euo pipefail`.
- **Pinning consistency**: every positive doc example now uses full-SHA pins (`@2192c47… # main` for this repo's workflows/actions; current release SHAs for third-party actions). Only deliberately-labeled WRONG examples and audit grep patterns retain mutable refs.
- **Markdown structural fixes**: six docs had 3-backtick fences nesting 3-backtick code blocks (broken rendering, one phantom broken image) — outer fences converted to 4 backticks; ~40 unlabeled fences tagged.
- **Link integrity**: ccpkg repo link (renamed), MIF/ccpkg spec deep links, private template repos de-linked, LICENSE added to back the README's MIT claim.
- **Compliance**: attested-delivery skill now satisfies the strict skill-doc standard; profile-maintainer agent aligned to the shared structure; CONTRIBUTING describes the real toolchain.

## Validation

- `actionlint` clean on the modified workflow (including the pre-existing SC2046 in the step I touched)
- `lychee` (offline + online, badges excluded): **0 errors** across all public-facing docs
- Fence-aware scan: zero unlabeled code fences remain in scope
- All 8 skills pass the Purpose/Triggers/Usage strict check
- pin-check simulation clean on both scanned dirs