### PR TITLE
docs(skills): bake attested-release learnings into skill definitions

### DIFF
--- a/.github/skills/attested-delivery/SKILL.md
+++ b/.github/skills/attested-delivery/SKILL.md
@@ -49,6 +49,11 @@ nine complete, parameterized workflows (`build-attest`, `sign-and-attest`,
 `dora-emit`, `pin-check`, `mirror-images`), validated end-to-end in a
 production rollout before being baked in. The skill is fully
 self-contained: no external repository access is required to apply it.
+For the **binaries/bundles flow** (no container), the reference
+implementations are `zircote/rlm-rs` and `zircote/rust-template`
+(`release.yml`, `publish.yml`, `package-homebrew.yml`) — proven via
+released versions and dispatch dry-runs; the full recipe is in
+`references/integration-recipes.md` (recipe D).
 
 **Before doing anything else**, read `references/platform-constraints.md` in
 this skill. Every entry was paid for with a failed release; violating any of
@@ -130,7 +135,7 @@ Wiring decision table:
 | No container build yet | Single `build-attest.yml` call — builds, pushes to GHCR by digest, signs/attests, self-verifies |
 | Build already pushes by digest | Call `sign-and-attest.yml` directly with `image-name` + `image-digest`, then `verify-attestation.yml` |
 | Multi-arch matrix build | Keep the matrix; add a manifest-digest capture step after the manifest merge; then sign/verify as above. Exact recipe in `references/integration-recipes.md` |
-| Binaries/bundles only (no image) | `actions/attest-build-provenance` per artifact; document `gh attestation verify <file> --repo <o>/<r>` |
+| Binaries/bundles only (no image) | Full recipe D: meta (var-driven via `cargo metadata`) → build matrix with build-time `attest-build-provenance` and `{bin}-{version}-{platform}` names → test/audit gates → SBOM attest → fail-closed verify BEFORE the tag-gated release; crates.io via Trusted Publishing + registry byte-compare + attest; templates ship `publish = false` as the channel gate |
 
 Required elements, all shapes:
 1. **Digest capture** (matrix shape): after `docker buildx imagetools create`,

--- a/.github/skills/attested-delivery/references/integration-recipes.md
+++ b/.github/skills/attested-delivery/references/integration-recipes.md
@@ -89,16 +89,66 @@ B's `sign`/`verify` consuming `needs.container-merge.outputs.image-digest`:
           echo "image-digest=$DIGEST" >> "$GITHUB_OUTPUT"
 ```
 
-## Caller recipe D — binaries/bundles only
+## Caller recipe D — binaries/bundles (the proven full release shape)
 
-```yaml
-      - uses: actions/attest-build-provenance@<full-sha>  # vX.Y.Z
-        with:
-          subject-path: target/release/<binary>
+Reference implementations: `zircote/rlm-rs` and `zircote/rust-template`
+(`release.yml`, `publish.yml`, `package-homebrew.yml`). The shape:
+
+```text
+[meta] -> [build xN + attest] -> [sbom + attest] -> [verify]** -> [release]*
+          [test] [audit] ---------------------------^
+(* tag-gated; ** fail-closed BEFORE the release exists)
 ```
+
+Required elements:
+
+1. **meta job** — resolve ALL project specificity at runtime so nothing
+   is renamed when a template is instantiated (var-driven):
+   ```sh
+   META=$(cargo metadata --no-deps --format-version 1)
+   BIN=$(jq -r '[.packages[0].targets[] | select(.kind | index("bin"))][0].name' <<< "$META")
+   # tag pushes: VERSION="${GITHUB_REF#refs/tags/v}"; dispatch dry-runs:
+   # VERSION="$(jq -r '.packages[0].version' <<< "$META")-dev"
+   ```
+2. **Build matrix** with versioned artifact names
+   `{bin}-{version}-{platform}` and `cargo build --release --locked`;
+   `actions/attest-build-provenance` per leg AT BUILD TIME (before any
+   release exists), then upload-artifact.
+3. **test + audit gates inside the release workflow** — tags are not
+   guaranteed to point at CI-green commits; the release tests itself.
+4. **SBOM**: anchore/sbom-action (CycloneDX) + `actions/attest-sbom` with
+   `subject-path: dist/*` — binds every binary to the SBOM.
+5. **Fail-closed verify job** before the release: assert the artifact
+   COUNT (a partial set must never publish), then per binary:
+   `gh attestation verify "$f" --repo "$GITHUB_REPOSITORY"` and the same
+   with `--predicate-type https://cyclonedx.org/bom`.
+6. **Tag-gated release job** (`needs: [meta, verify, audit, test]`) with a
+   single `{bin}-{version}-checksums.txt`; `tag_name: ${{ github.ref_name }}`.
+
+**crates.io** (separate `publish.yml`): pre-publish gauntlet with
+`--locked`, then Trusted Publishing (OIDC, `rust-lang/crates-io-auth-action`,
+no long-lived token; one-time crates.io setup names the workflow file and
+environment). After publish: download the registry-served `.crate`
+(`curl -fsSL -A '<name>-release-check'` — constraint 15), byte-compare to
+`target/package/`, attest the registry bytes. Guard BEFORE publish:
+tag version must equal the manifest version (constraint 14).
+
+**Homebrew** (separate `package-homebrew.yml`): `workflow_run` on the
+Release workflow (constraint 17); formula SHA via
+`set -euo pipefail` + `curl -fsSL` (constraint 16); generate the formula
+into the workspace so dry-runs need neither the tap nor its token.
+
+**Template gate**: template repos ship `publish = false` in Cargo.toml.
+Each publication job reads it via `cargo metadata` AT THE PACKAGED REF
+(`if .packages[0].publish == [] then "false" else "true" end`) and skips
+release creation / crates.io / Homebrew while the attest→verify chain
+still runs as CI validation. Downstream projects delete the one line to
+arm all channels; cargo itself refuses `cargo publish` as a second lock.
+
 Verification for consumers: `gh attestation verify <file> --repo <org>/<repo>`
 (no `--signer-workflow` here — the SAN *is* the repo's own workflow when
-attestation happens outside the central signer).
+attestation happens outside the central signer); SBOM binding via
+`--predicate-type https://cyclonedx.org/bom`.
 
 ## Release gating and dry-run (all shapes)
 

--- a/.github/skills/attested-delivery/references/platform-constraints.md
+++ b/.github/skills/attested-delivery/references/platform-constraints.md
@@ -144,3 +144,95 @@ gh api 'orgs/<org>/packages/container/<name>/versions?per_page=20' \
 **Fix:** read the context name off an actual run before adding it to
 branch protection; update protection in the same motion as renaming any
 job that is a required check.
+
+## 13. `secrets` context in `if:` kills the whole caller graph
+
+**Symptom:** every run of an orchestrator workflow startup-fails with zero
+jobs ("This run likely failed because of a workflow file issue") on every
+event — PRs and pushes alike — and branch pushes emit orphan failure runs
+attributed to a *called* workflow file that has no matching trigger.
+**Cause:** the `secrets` context is not available in `if:` expressions
+(e.g. `if: secrets.SOME_TOKEN != ''`). The expression makes the called
+file a compile error; one broken local reusable workflow invalidates the
+entire caller graph. The error never names the offending line, and the
+push-event failure runs are attributed to the called file, not the caller.
+(rust-template shipped this for six weeks — every Pipeline run dead.)
+**Fix:** expose the secret via job-level `env:` and gate on
+`env.SOME_TOKEN != ''`. Audit with:
+```sh
+grep -rn 'if:.*secrets\.' .github/workflows/
+```
+
+## 14. `cargo publish` ships the manifest version, not the tag
+
+**Symptom:** tag `v1.4.0` is pushed but crates.io receives `1.3.1`; the
+post-publish download/attest step then fails looking for a `1.4.0` crate.
+**Cause:** `cargo publish` reads the version from Cargo.toml and ignores
+the git tag entirely. crates.io versions are immutable — a wrong publish
+cannot be undone.
+**Fix:** a tag-gated guard before publish:
+```sh
+TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+[ "$TAG_VERSION" = "$CARGO_VERSION" ] || exit 1
+```
+Also run pre-publish `clippy`/`test`/`doc` with `--locked` so the release
+run cannot silently rewrite Cargo.lock.
+
+## 15. static.crates.io rejects UA-less requests
+
+**Symptom:** registry `.crate` downloads fail or hang intermittently in CI
+and on workstations, while the publish itself succeeded.
+**Cause:** crates.io's CDN can reject requests without a User-Agent,
+silently.
+**Fix:** always `curl -fsSL -A '<name>-release-check' …` when fetching
+from static.crates.io or the crates.io API.
+
+## 16. `curl -sL | shasum` hashes error pages
+
+**Symptom:** a Homebrew formula (or any checksum manifest) carries a
+syntactically valid SHA256 that matches nothing — installs fail with
+checksum mismatch.
+**Cause:** `curl` without `-f` emits HTML error bodies on HTTP failures,
+and without `pipefail` the pipeline exits with `shasum`'s success.
+**Fix:** `set -euo pipefail` and `curl -fsSL` in every download-then-hash
+pipeline. A failed download must kill the step, loudly.
+
+## 17. Bot-authored releases don't trigger `release` workflows
+
+**Symptom:** the Homebrew/packaging workflow never fires after a release
+created by a workflow, even with `release: types: [published]`.
+**Cause:** events authored by `github-actions[bot]` (the release-creating
+workflow's token) do not trigger workflows — by design, to prevent loops.
+**Fix:** trigger packaging via `workflow_run` on the Release workflow's
+completion. In that payload, `head_branch` IS the tag name for
+tag-triggered runs (and there is no `ref` field). Optionally also create
+the release with a PAT so the `release` event fires as a secondary path.
+
+## 18. Actions REST replicas serve stale run/job views
+
+**Symptom:** `runs/{id}` flips between `in_progress` and
+`completed/success`; `runs/{id}/jobs` omits jobs another query just
+returned; a freshly reported run 404s.
+**Cause:** API replica lag — different replicas answer successive calls
+for minutes after state changes.
+**Fix:** before acting on a run's completion, double-confirm (two
+consecutive consistent reads, ≥60s apart). For PR merge gates, never use
+"zero pending checks" alone — right after a push only 1–2 checks are
+registered and the window reads as falsely green; require the aggregate
+gate check (e.g. `All Checks Pass`) to have *reported* a conclusion.
+
+## 19. User-account rulesets: no Integration bypass, and bots can't push
+
+**Symptom:** creating a ruleset with a GitHub Actions app bypass actor
+fails with "Actor GitHub Actions integration must be part of the ruleset
+source or owner organization"; with required status checks active, any
+workflow step that commits directly to the protected branch (e.g. a
+CHANGELOG auto-commit via the contents API) is rejected.
+**Cause:** personal-account repo rulesets support only
+RepositoryRole/DeployKey bypass actors, and `github-actions[bot]` is not
+an admin — required checks block its direct pushes.
+**Fix:** design release flows to never push to protected branches
+(maintain changelogs in the release-prep PR; carry release notes in the
+release body). If an automated push is unavoidable, use a deploy key
+with a DeployKey bypass actor.

--- a/.github/skills/attested-delivery/references/verification.md
+++ b/.github/skills/attested-delivery/references/verification.md
@@ -12,12 +12,13 @@ gh auth token | docker login ghcr.io -u <username> --password-stdin
 ## 0. Resolve the digest for a tag
 
 ```sh
-DIGEST=$(gh api 'orgs/<org>/packages/container/<name>/versions?per_page=20' \
+DIGEST=$(gh api 'orgs/<org>/packages/container/<name>/versions?per_page=100' \
   --jq '[.[] | select((.metadata.container.tags // []) | index("<tag>"))][0].name')
 ```
 
 For a personal (user) account, the packages endpoints use
-`users/<owner>/...` instead of `orgs/<org>/...`.
+`users/<owner>/...` instead of `orgs/<org>/...`. Use `per_page=100` —
+20 misses older tags and returns `null`, which reads as a false failure.
 
 ## 1. SLSA provenance (AT-05)
 
@@ -54,9 +55,24 @@ cosign verify-attestation "ghcr.io/<org>/<repo>@${DIGEST}" \
 
 ```sh
 gh release download <tag> --repo <org>/<repo>
-gh attestation verify <binary> --repo <org>/<repo>
+gh attestation verify <binary> --repo <org>/<repo>                  # provenance
+gh attestation verify <binary> --repo <org>/<repo> \
+  --predicate-type https://cyclonedx.org/bom                        # SBOM binding
+shasum -a 256 -c <bin>-<version>-checksums.txt
 ```
 (No `--signer-workflow` for artifacts attested by the repo's own workflow.)
+
+## 5. Published crates
+
+```sh
+# static.crates.io rejects UA-less requests — always set -A
+curl -fsSL -A 'release-check' \
+  -O https://static.crates.io/crates/<name>/<name>-<version>.crate
+gh attestation verify <name>-<version>.crate --repo <org>/<repo>
+```
+
+Check **exit codes**, not grepped output — a filtered pipe that matches
+nothing looks identical to success. Silence is not success.
 
 ## Expected outcomes
 

--- a/.github/skills/template-creation/SKILL.md
+++ b/.github/skills/template-creation/SKILL.md
@@ -61,6 +61,36 @@ Use these placeholders (replaced by new-project.sh):
 | `{{package_name}}` | Underscore name | `my_api` |
 | `{{ProjectName}}` | PascalCase name | `MyApi` |
 
+## Var-Driven Workflows (release automation has NO placeholders)
+
+Placeholders are for docs and source files. Release/publish/packaging
+workflows must instead resolve ALL project specificity at runtime so they
+are correct the moment the template is instantiated — nothing to rename,
+nothing that can be missed:
+
+- crate/package/binary name, version, description, license → from the
+  language manifest at runtime (e.g. `cargo metadata --no-deps`,
+  `node -p "require('./package.json').name"`)
+- owner/repo → `${{ github.repository }}` / `${{ github.repository_owner }}`
+- anything not derivable → a repository variable with a sane default
+  (e.g. `${{ vars.HOMEBREW_TAP_REPO || 'homebrew-tap' }}`)
+
+Reference implementation: `zircote/rust-template`
+(`release.yml`, `publish.yml`, `package-homebrew.yml`).
+
+## Publication Channels: created but disabled
+
+Template repos publish nothing, but must ship working publication
+workflows. Gate them on a single deterministic switch in the manifest the
+user already edits — for Rust, `publish = false` in Cargo.toml:
+
+- each publication job reads the flag via the manifest AT THE PACKAGED REF
+  and skips (GitHub Release creation, registry publish, Homebrew/tap)
+- the build → attest → verify chain still runs as CI validation
+- the language tooling enforces it too (`cargo publish` refuses while set)
+- instantiation deletes the one line to arm every channel — wire this into
+  the template's init flow
+
 ## Workflow Standards
 
 All CI workflows must:
@@ -164,6 +194,9 @@ cd /tmp/test-project
 - Latest stable Rust
 - `clippy` (pedantic), `cargo-deny`
 - Documentation tests
+- Attested releases per the attested-delivery skill (recipe D); var-driven
+  release workflows; `publish = false` channel gate (see
+  `zircote/rust-template`)
 
 ### Java Templates
 - Java 21 LTS, Spring Boot 3.3+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,7 @@ vulnerability report as OCI referrers. Verify from any workstation with `gh`
 
 ```sh
 # 0. Resolve the digest for a tag
-DIGEST=$(gh api 'users/zircote/packages/container/<name>/versions?per_page=20' \
+DIGEST=$(gh api 'users/zircote/packages/container/<name>/versions?per_page=100' \
   --jq '[.[] | select((.metadata.container.tags // []) | index("<tag>"))][0].name')
 
 # 1. SLSA provenance — --repo asserts where the build ran,


### PR DESCRIPTION
Canonicalizes this week's proven learnings from the zircote/rust-template consistency port (PRs #78–#82) and the zircote/rlm-rs backport into the skill definitions.

## attested-delivery skill
- **platform-constraints.md**: entries 13–19 — `secrets` in `if:` compile errors killing entire caller graphs (rust-template's pipeline was dead for six weeks); `cargo publish` shipping the manifest version regardless of tag; static.crates.io User-Agent; `curl|shasum` hashing error pages; bot-authored releases not firing `release` events (workflow_run + head_branch-is-the-tag); Actions REST replica staleness (double-confirm; aggregate-gate PR predicates); user-account ruleset bypass limits.
- **integration-recipes.md**: recipe D is now the full proven binaries shape — var-driven meta, build-time attestation with versioned names, in-release test/audit gates, SBOM attest, fail-closed verify before the release exists, Trusted Publishing + registry byte-compare + crate attestation, workflow_run Homebrew, and the `publish = false` template gate.
- **verification.md**: binary SBOM predicate, crate verification, per_page 100, exit-codes-not-grep.
- **SKILL.md**: binaries wiring row → full recipe D; rlm-rs + rust-template named as binary-flow reference implementations.

## template-creation skill
- Var-driven release workflows (no placeholders in release automation — manifest + GitHub context at runtime).
- Publication channels created but disabled via the manifest gate, armed by deleting one line at instantiation.

## SECURITY.md
- Digest resolution `per_page` 20 → 100 (older tags returned null).