### PR TITLE
feat: gh-attested skill + attested quality-gate workflows

### DIFF
--- a/.github/skills/gh-attested/SKILL.md
+++ b/.github/skills/gh-attested/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: gh-attested
+description: Assess, plan, and implement complete attested quality-gate coverage for a public open-source repo using GitHub-native + free-for-OSS tooling — SAST, SCA, secrets, container/IaC/license, SBOM, VEX, provenance, posture, peer review, load, DAST — each gate's verdict turned into a signed, digest-bound attestation. USE THIS SKILL when user says "assess quality gates", "attested quality gates", "attest CI gates", "add CodeQL/OSV-Scanner/Trivy/Scorecard", "SAST/SCA/DAST attestation", "free-for-OSS security gates", or "wire attested quality gates".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# gh-attested — Attested Quality Gates (assess → plan → implement)
+
+## Purpose
+
+Bring a public open-source repository to **complete quality-gate coverage**
+using only GitHub-native and free-for-OSS tooling, and turn each gate's verdict
+into a **signed, digest-bound attestation**. The skill **assesses** current
+coverage against the 12-gate map, **plans** the gaps, and **implements** them by
+wiring the target as a thin caller of this org's central reusable workflows.
+
+This skill **composes with**, and does not duplicate:
+
+- `attested-delivery` — the container release backbone (SLSA L3 build
+  provenance, cosign signing, SBOM/vuln attestation, fail-closed verify,
+  `pin-check`). Defer build-provenance and `attest-sbom` to it.
+- `reusable-security.yml` — gitleaks + per-language dependency audits.
+- `sbom-and-scan.yml` — CycloneDX/SPDX SBOM + Grype.
+
+## Triggers
+
+- "assess this repo's quality-gate coverage"
+- "wire attested quality gates / make every CI gate produce an attestation"
+- "add CodeQL SAST / OSV-Scanner / Trivy / OpenSSF Scorecard / OpenVEX"
+- "set up free-for-OSS security gates and enforce them"
+- "verify the gate attestations for a release"
+
+## Architecture invariant
+
+A gate's verdict reaches the **merge or deploy decision only as a signed
+attestation whose signer identity is pinned**. A clean SARIF in the Security
+tab is *evidence*; the attestation — an in-toto statement binding a typed
+predicate to a subject by digest, signed by a central reusable workflow's OIDC
+identity — is the *enforceable claim*. Because signing runs in a central
+reusable workflow the caller cannot modify, the Fulcio certificate SAN is the
+central signer (SLSA Build L3); verifiers MUST pin `--signer-workflow`, not just
+`--owner`.
+
+Two honest caveats, always in force:
+
+- **A signed attestation proves a gate ran and recorded a verdict, not that it
+  passed.** The verifying policy must read the verdict field.
+- **Free GitHub-proprietary scanners (CodeQL, secret scanning, dependency
+  review) are free only on public repos.** This skill targets the public-repo
+  free path; the private/licensed path is documented in
+  `references/limitations.md`.
+
+## The 12-gate map → provider
+
+| Gate | Provider workflow |
+| --- | --- |
+| SAST | `reusable-sast-codeql.yml` |
+| SCA | `reusable-sca-osv.yml` (+ Dependabot, repo config) |
+| Secret detection | native secret scanning + push protection (config) + gitleaks in `reusable-security.yml` |
+| Container + IaC + license | `reusable-trivy.yml` |
+| SBOM | `sbom-and-scan.yml` + `attest-sbom` (attested-delivery) |
+| Vuln disposition (VEX) | `reusable-vex.yml` |
+| Build provenance | `attested-delivery` (`sign-and-attest.yml`) |
+| Supply-chain posture | `reusable-scorecard.yml` |
+| Peer review | rulesets / branch protection / CODEOWNERS / Gitsign (config) |
+| Load / perf (opt-in) | `reusable-k6.yml` |
+| DAST (opt-in) | `reusable-zap.yml` |
+| Attestation seam | `reusable-attest-scan.yml` (signs any evidence file) |
+| Fail-closed gate verify | `reusable-verify-gates.yml` |
+
+## Phase protocol
+
+Each phase ends with a verify gate. Do not proceed past a failing gate.
+
+### Phase 0 — Assess (read-only)
+
+Run the queries in `references/assessment.md` and emit a **coverage matrix**:
+for each of the 12 gates — present? attested? a merge gate? a deploy gate? Cover
+repo visibility (public ⇒ free tier), languages/build systems (drives CodeQL
+languages and which SCA ecosystems), whether a container image or a running app
+exists (drives Trivy image scan, k6, ZAP), default branch via the API
+(`gh api repos/<o>/<r> --jq .default_branch`), existing workflows, branch
+protection / rulesets, environments, and Dependabot config.
+
+Gate: a written coverage matrix naming present gates, gaps, and in-scope gates.
+
+### Phase 1 — Plan
+
+Map each gap to the provider table. Include k6/ZAP **only** when a running app
+and a load script / target URL exist — otherwise mark them documented-not-wired.
+Confirm public-repo free tier vs the private licensing note. Produce the wiring
+list (which reusables, which inputs, which predicate types).
+
+Gate: an agreed gate list with predicate-type assignments (see
+`references/gate-catalog.md`).
+
+### Phase 2 — Implement (repo level)
+
+Wire the target as a thin caller of the central reusables, **pinned by the full
+40-char commit SHA** of this central repo. Required elements:
+
+1. A `quality-gates.yml` caller (model: `templates/quality-gates-caller.yml`)
+   that fans out the in-scope gates on `push` / `pull_request`.
+2. **The seam**: for every gate whose verdict must gate *deployment* (not just
+   merge), upload the evidence file as an artifact and call
+   `reusable-attest-scan.yml` with the gate's predicate type so it becomes a
+   signed, digest-bound attestation.
+3. `dependabot.yml` (github-actions ecosystem) so the new pins stay fresh.
+4. SECURITY.md "Verifying Quality-Gate Attestations" (from
+   `references/verification.md`).
+5. Migrate every `uses:` to full 40-char SHAs; add the central `pin-check.yml`
+   as a CI job (later a required check).
+
+Gate: `actionlint` clean; PR opens; pipeline green including `pin-check`.
+
+### Phase 3 — Enforce & provision (the safety contract)
+
+Apply the templated repo configuration per `references/repo-config.md`. The
+hard split:
+
+- **Deploy automatically (idempotent, non-secret, reversible)** — but only
+  after a **diff-against-current preview + explicit confirm**: the ruleset
+  (`templates/ruleset.json`: required status checks for the in-scope gates +
+  `pin-check / pin-check`, required reviews + CODEOWNERS, dismiss-stale, signed
+  commits, linear history, block force-push); repo settings (auto-merge,
+  delete-branch-on-merge); native free-tier scanners (code-scanning default
+  setup, secret scanning, push protection); `dependabot.yml` and `CODEOWNERS`
+  (committed via PR); deploy environments + wait timer + branch policy.
+  Compose with the `gpm` skills (`gpm-branch-protection`, `gpm-repo-settings`,
+  `gpm-labels`) — call them, do not reinvent.
+- **Guide only — never written, never logged**: secrets and variables. Emit the
+  required **names** and the exact `gh secret set NAME` / `gh variable set NAME`
+  command for the user to run; never read, write, commit, or print a secret
+  value. Most gates need **no secrets** (keyless signing + OSS scanners);
+  `GITLEAKS_LICENSE` and deploy credentials are the only common optionals.
+  Environment required-reviewers (human identities) are a manual step.
+
+Deploy-time: `reusable-verify-gates.yml` in the deploy job's `needs:` —
+fail-closed `gh attestation verify` before anything ships.
+
+Gate: config applied idempotently (re-run = no-op); transcript shows only secret
+*names* and user-run commands, never values.
+
+### Phase 4 — Verify end-to-end
+
+1. `actionlint` clean; `pin-check` zero unpinned `uses:`.
+2. Dispatch the caller (or open the first PR). The chain runs SAST → SCA →
+   posture → container/IaC/license → SBOM → seam-attest → verify; SARIF lands in
+   the Security tab; `reusable-attest-scan.yml` produces a signed attestation.
+3. Run every command in `references/verification.md` **independently** from a
+   workstation against the produced attestation — in-pipeline success is not the
+   acceptance test.
+
+## Hard rules
+
+1. **Pin every third-party action by full 40-char SHA.** The Trivy
+   `trivy-action` compromise (CVE-2026-33634, March 2026 — 76 of 77 tags
+   force-pushed to malware) is the standing cautionary case. Tags are unsafe.
+2. `gh attestation verify` under SLSA L3: `--owner` alone is insufficient —
+   the SAN is the central signer; always add `--signer-workflow`.
+   `--cert-identity-regexp` / `--cert-oidc-issuer` are cosign flags; `gh`
+   rejects them.
+3. **Least privilege.** `id-token: write` + `attestations: write` only on jobs
+   that sign; `security-events: write` only on jobs that upload SARIF.
+4. **Never read, write, commit, or log a secret value.** Emit names + the
+   user-run command only.
+5. A signed attestation proves a gate *ran and recorded a verdict*, not that it
+   *passed* — the policy reads the verdict.
+6. Default branch from the API, never local `origin/HEAD`.
+
+## References
+
+- `references/gate-catalog.md` — the 12 gates: tool, reusable, pinned action, evidence, predicate-type URI, merge vs deploy, free-for-OSS
+- `references/assessment.md` — coverage-assessment `gh` queries + the matrix template
+- `references/attestation-seam.md` — `actions/attest` custom-predicate mechanics; per-gate predicate URIs; compose-with-attested-delivery
+- `references/enforcement.md` — SARIF hub → required checks → rulesets → environments → fail-closed verify; the k8s-admission boundary
+- `references/verification.md` — the exact `gh attestation verify` command set per predicate
+- `references/repo-config.md` — the deploy-vs-guide safety contract for repo configuration
+- `references/limitations.md` — honest limits: licensing line, no k8s admission, no perf predicate, ZAP SARIF caveat, action supply-chain risk, "signed ≠ passed"

--- a/.github/skills/gh-attested/references/assessment.md
+++ b/.github/skills/gh-attested/references/assessment.md
@@ -1,0 +1,89 @@
+# Phase 0 — Assessment procedure
+
+Read-only. Produce a coverage matrix before proposing any change. Replace
+`<o>/<r>` with owner/repo.
+
+## Repo shape
+
+```bash
+# Visibility (public ⇒ free GitHub-proprietary scanners) and default branch
+gh api repos/<o>/<r> --jq '{visibility, default_branch, language}'
+
+# Languages present (drives CodeQL languages + SCA ecosystems)
+gh api repos/<o>/<r>/languages
+
+# Is there a container image / Dockerfile? A running app / load script?
+gh api repos/<o>/<r>/contents --jq '.[].name' | grep -iE 'dockerfile|compose' || true
+```
+
+## Native free-tier scanners (public repos)
+
+```bash
+# Code scanning (CodeQL) default-setup state
+gh api repos/<o>/<r>/code-scanning/default-setup --jq '{state, languages}' 2>/dev/null \
+  || echo "default setup not configured"
+
+# Secret scanning + push protection + dependency review (security_and_analysis)
+gh api repos/<o>/<r> --jq '.security_and_analysis'
+
+# Open code-scanning alerts (any tool) — counts as "gate present but findings open"
+gh api 'repos/<o>/<r>/code-scanning/alerts?state=open&per_page=1' --jq 'length' 2>/dev/null || true
+```
+
+## Supply-chain config
+
+```bash
+# Dependabot config present?
+gh api repos/<o>/<r>/contents/.github/dependabot.yml --jq '.path' 2>/dev/null || echo "no dependabot.yml"
+
+# Dependabot alerts enabled?
+gh api repos/<o>/<r>/vulnerability-alerts -i 2>/dev/null | head -1   # 204 = enabled, 404 = not
+```
+
+## Existing workflows + pinning posture
+
+```bash
+# Inventory workflows
+gh api repos/<o>/<r>/contents/.github/workflows --jq '.[].name' 2>/dev/null || echo "no workflows"
+
+# Count tag-pinned (unsafe) uses: — should be zero after Phase 2
+gh api repos/<o>/<r>/contents/.github/workflows --jq '.[].path' 2>/dev/null \
+  | while read -r p; do gh api "repos/<o>/<r>/contents/$p" --jq '.content' \
+  | base64 -d | grep -nE 'uses:.*@(v[0-9]|main|master)' || true; done
+```
+
+## Enforcement state
+
+```bash
+# Rulesets / branch protection on the default branch
+gh api repos/<o>/<r>/rulesets --jq '.[].name' 2>/dev/null || true
+gh api repos/<o>/<r>/branches/<default>/protection --jq \
+  '{checks: .required_status_checks.contexts, reviews: .required_pull_request_reviews}' 2>/dev/null \
+  || echo "no branch protection"
+
+# Environments (deploy gates)
+gh api repos/<o>/<r>/environments --jq '.environments[].name' 2>/dev/null || echo "none"
+```
+
+## Coverage matrix template
+
+Fill one row per gate. `Present` = a workflow/config exists; `Attested` = its
+verdict is a signed attestation; `Merge`/`Deploy` = it gates that decision.
+
+| Gate | Present | Attested | Merge gate | Deploy gate | Gap / action |
+|------|:---:|:---:|:---:|:---:|------|
+| SAST (CodeQL) | | | | | |
+| SCA (OSV + dep-review + Dependabot) | | | | | |
+| Secret detection | | | | | |
+| Container vuln (Trivy) | | | | | |
+| IaC + license (Trivy) | | | | | |
+| SBOM | | | | | |
+| Vuln disposition (VEX) | | | | | |
+| Build provenance | | | | | |
+| Supply-chain posture (Scorecard) | | | | | |
+| Peer review (rulesets/CODEOWNERS) | | | | | |
+| Load / perf (k6) | | | | | |
+| DAST (ZAP) | | | | | |
+
+Exit Phase 0 with this matrix and a list of in-scope gates (mark k6/ZAP
+out-of-scope unless a running target exists).

--- a/.github/skills/gh-attested/references/attestation-seam.md
+++ b/.github/skills/gh-attested/references/attestation-seam.md
@@ -63,7 +63,12 @@ share a filesystem across caller jobs).
 | SBOM | SPDX / CycloneDX via `attest-sbom` (attested-delivery) |
 
 The custom `zircote.github.io/...` URIs need not resolve to a live document —
-they are stable type identifiers a verifier pins with `--predicate-type`.
+they are stable type identifiers a verifier pins with `--predicate-type`. Each
+custom type is **defined** (body format, verdict rule, JSON Schema) in the
+repo at
+[`docs/reference/attestation-predicates/`](../../../../docs/reference/attestation-predicates/README.md);
+that tree is the source of truth and what gets published if the namespace is
+ever served.
 
 ## What the subject is
 

--- a/.github/skills/gh-attested/references/attestation-seam.md
+++ b/.github/skills/gh-attested/references/attestation-seam.md
@@ -1,0 +1,83 @@
+# The attestation seam — turning any gate verdict into a signed claim
+
+## The primitive
+
+An in-toto Statement binds a typed `predicate` to a subject by content
+`digest`; a DSSE envelope signs it so the claim is authenticated and
+tamper-evident. GitHub Artifact Attestations make this keyless: a job declaring
+`id-token: write` + `attestations: write` exchanges its OIDC identity for a
+short-lived Sigstore certificate — no keys, no KMS. Public repos use the
+Sigstore Public Good instance and write to a public transparency log.
+
+Three actions cover the common predicates; one covers everything else:
+
+- `actions/attest-build-provenance` → SLSA build provenance (deferred to
+  `attested-delivery`).
+- `actions/attest-sbom` → SPDX/CycloneDX SBOM (deferred to `attested-delivery`
+  / `sbom-and-scan.yml`).
+- `actions/attest` → **the seam**: any `predicate-type` URI + a `predicate-path`
+  file, bound to `subject-digest`. This is what makes a scanner's SARIF/JSON a
+  first-class signed claim.
+
+## The central seam workflow
+
+`reusable-attest-scan.yml` wraps `actions/attest`. It downloads an evidence
+artifact (uploaded by the gate job) and signs the named file as a custom
+predicate bound to `subject-digest`. Because it is a *central reusable
+workflow*, the Fulcio SAN is the central signer — SLSA L3 isolation — and
+verifiers pin `--signer-workflow`.
+
+```yaml
+attest-sast:
+  needs: [build, sast]            # build emits the subject digest; sast emits SARIF
+  permissions:
+    id-token: write
+    attestations: write
+    contents: read
+  uses: zircote/.github/.github/workflows/reusable-attest-scan.yml@<sha>
+  with:
+    subject-name: ghcr.io/zircote/app
+    subject-digest: ${{ needs.build.outputs.digest }}
+    predicate-type: https://zircote.github.io/attestations/sast/v1
+    predicate-artifact: codeql-sarif      # uploaded by the sast job
+    predicate-filename: results.sarif
+```
+
+The gate job must `actions/upload-artifact` its evidence file under
+`predicate-artifact` so the seam job can download it (reusable workflows do not
+share a filesystem across caller jobs).
+
+## Predicate-type URIs
+
+| Gate | Predicate type |
+|------|----------------|
+| SAST | `https://zircote.github.io/attestations/sast/v1` |
+| SCA | `https://zircote.github.io/attestations/sca/v1` |
+| Container vuln | `https://zircote.github.io/attestations/container-scan/v1` |
+| IaC + license | `https://zircote.github.io/attestations/iac-license/v1` |
+| Posture (Scorecard) | `https://zircote.github.io/attestations/scorecard/v1` |
+| Load (k6) | `https://zircote.github.io/attestations/k6-load/v1` |
+| DAST (ZAP) | `https://zircote.github.io/attestations/dast/v1` |
+| Vuln disposition | `https://openvex.dev/ns/v0.2.0` (standard) |
+| Build provenance | `https://slsa.dev/provenance/v1` (standard, attested-delivery) |
+| SBOM | SPDX / CycloneDX via `attest-sbom` (attested-delivery) |
+
+The custom `zircote.github.io/...` URIs need not resolve to a live document —
+they are stable type identifiers a verifier pins with `--predicate-type`.
+
+## What the subject is
+
+For a container release the subject is the image digest (shared with
+`attested-delivery`). For non-container projects, the subject is whatever
+artifact the gates concern — a release tarball digest, a built binary digest, or
+a logical name + a computed `sha256:` of the source snapshot. Use the **same**
+subject across all of a release's gate attestations so one `verify` covers them.
+
+## Compose, don't duplicate
+
+- Build provenance + SBOM: call `attested-delivery` (`sign-and-attest.yml`) —
+  do not re-sign these here.
+- Secret scanning + language audits: already in `reusable-security.yml`.
+- SBOM + Grype: already in `sbom-and-scan.yml`.
+
+The seam adds attestations only for the gates those do not already sign.

--- a/.github/skills/gh-attested/references/enforcement.md
+++ b/.github/skills/gh-attested/references/enforcement.md
@@ -29,13 +29,17 @@ before it runs or reads the environment's secrets.
 
 The cryptographic gate slots into the same deploy job: `reusable-verify-gates.yml`
 runs `gh attestation verify` for each required predicate and exits non-zero on
-any failure. Put it in the deploy job's `needs:` so an unverified or
-improperly-signed artifact never ships:
+any failure. **It verifies one signer per invocation** — pin `signer-workflow`
+to the workflow that actually produced those predicates (the "Signed by" column
+in `docs/reference/attestation-predicates/`). The seam
+(`reusable-attest-scan.yml`) signs the SARIF gates; OpenVEX self-signs in
+`reusable-vex.yml`; k6 in `reusable-k6.yml`. Mixing predicates from different
+signers into one call fails closed on a *valid* artifact, so call it once per
+signer group and have the deploy job `needs:` them all:
 
 ```yaml
-verify:
+verify-seam:
   permissions:
-    id-token: write
     contents: read
     attestations: read
     packages: read
@@ -47,9 +51,19 @@ verify:
     predicate-types: |-
       https://zircote.github.io/attestations/sast/v1
       https://zircote.github.io/attestations/sca/v1
-      https://openvex.dev/ns/v0.2.0
+verify-vex:
+  permissions:
+    contents: read
+    attestations: read
+    packages: read
+  uses: zircote/.github/.github/workflows/reusable-verify-gates.yml@<sha>
+  with:
+    subject-ref: oci://ghcr.io/zircote/app@${{ needs.build.outputs.digest }}
+    owner: zircote
+    signer-workflow: zircote/.github/.github/workflows/reusable-vex.yml
+    predicate-types: https://openvex.dev/ns/v0.2.0
 deploy:
-  needs: [verify]
+  needs: [verify-seam, verify-vex]
   environment: production
   ...
 ```

--- a/.github/skills/gh-attested/references/enforcement.md
+++ b/.github/skills/gh-attested/references/enforcement.md
@@ -1,0 +1,65 @@
+# Enforcement — merge-time and deploy-time, all GitHub-native
+
+## Merge-time: required status checks + rulesets
+
+Every SARIF-emitting gate lands in the code-scanning hub; the **code scanning
+results** check fails a PR on any error/critical/high finding. Make gates merge
+blockers by adding their checks to **required status checks** in a ruleset (or
+branch protection). The context name for a reusable-workflow job is
+`<caller job id> / <called job name>` — e.g. a caller job `sast:` calling
+`reusable-sast-codeql.yml` (job `analyze`) surfaces as `sast / analyze`.
+
+Recommended required checks for a wired repo:
+
+- `Code scanning results / CodeQL` (and the third-party SARIF categories)
+- `sca / dependency-review`
+- `trivy / iac-license` (and `trivy / image` when an image is built)
+- `pin-check / pin-check`
+- the repo's own build/test checks
+
+Ruleset also enforces: required PR reviews + review from CODEOWNERS, dismiss
+stale approvals, **require signed commits** (satisfiable keyless via Gitsign),
+linear history, block force-push. Template: `templates/ruleset.json`.
+
+## Deploy-time: environments + fail-closed verify
+
+Deployment **Environments** add required reviewers, a wait timer, and
+deployment-branch policies; a job referencing an environment must clear them
+before it runs or reads the environment's secrets.
+
+The cryptographic gate slots into the same deploy job: `reusable-verify-gates.yml`
+runs `gh attestation verify` for each required predicate and exits non-zero on
+any failure. Put it in the deploy job's `needs:` so an unverified or
+improperly-signed artifact never ships:
+
+```yaml
+verify:
+  permissions:
+    id-token: write
+    contents: read
+    attestations: read
+    packages: read
+  uses: zircote/.github/.github/workflows/reusable-verify-gates.yml@<sha>
+  with:
+    subject-ref: oci://ghcr.io/zircote/app@${{ needs.build.outputs.digest }}
+    owner: zircote
+    signer-workflow: zircote/.github/.github/workflows/reusable-attest-scan.yml
+    predicate-types: |-
+      https://zircote.github.io/attestations/sast/v1
+      https://zircote.github.io/attestations/sca/v1
+      https://openvex.dev/ns/v0.2.0
+deploy:
+  needs: [verify]
+  environment: production
+  ...
+```
+
+## The honest boundary — no Kubernetes admission control
+
+GitHub gates **merges** and **deployment jobs**; it does **not** validate or
+reject workloads as they admit to a cluster. If you need the runtime gate —
+verify the same attestations at the cluster boundary — that piece (Sigstore
+policy-controller or Kyverno) is **external** to GitHub. The OSS tools are free,
+but they are not GitHub features and are out of scope for this skill. Design
+references for admission live in the central repo's
+`docs/how-to/enforce-admission-of-attested-images.md` (attested-delivery).

--- a/.github/skills/gh-attested/references/gate-catalog.md
+++ b/.github/skills/gh-attested/references/gate-catalog.md
@@ -1,0 +1,47 @@
+# Gate catalog — the 12 gates
+
+Distilled from `GITHUB-NATIVE-ATTESTED-QUALITY-GATES.md` (§3–§4). Every box is
+free-for-OSS (public repos). Predicate-type URIs under `zircote.github.io/...`
+are this org's custom predicates (no standard type exists for those gates);
+OpenVEX and SLSA provenance use their standard URIs. Pin actions are listed with
+the SHA used by the central reusable workflow.
+
+| # | Gate | Central reusable | Tool / pinned action | Evidence | Predicate type | Merge gate | Deploy gate |
+|---|------|------------------|----------------------|----------|----------------|:---:|:---:|
+| 1 | SAST | `reusable-sast-codeql.yml` | `github/codeql-action@38697555…` (v4.34.1) | SARIF → code scanning | `https://zircote.github.io/attestations/sast/v1` | ✅ code-scanning check | ✅ seam |
+| 2 | SCA | `reusable-sca-osv.yml` | `google/osv-scanner-action@9a498708…` (v2.3.8) + `actions/dependency-review-action@a1d282b3…` (v5.0.0) | SARIF + PR check | `https://zircote.github.io/attestations/sca/v1` | ✅ dep-review + check | ✅ seam |
+| 3 | Secret detection | native + `reusable-security.yml` | secret scanning + push protection (config) + `gitleaks/gitleaks-action` | alerts; push block | n/a (preventive) | ✅ push protection | — |
+| 4 | Container vuln | `reusable-trivy.yml` (image) | `aquasecurity/trivy-action@ed142fd0…` (v0.36.0) | SARIF | `https://zircote.github.io/attestations/container-scan/v1` | ✅ | ✅ seam |
+| 5 | IaC + license | `reusable-trivy.yml` (fs) | `aquasecurity/trivy-action@ed142fd0…` | SARIF | `https://zircote.github.io/attestations/iac-license/v1` | ✅ code-scanning check | ✅ seam |
+| 6 | SBOM | `sbom-and-scan.yml` + attested-delivery | Syft / `actions/attest-sbom` | SPDX / CycloneDX | `attest-sbom` (SPDX/CycloneDX) | — | ✅ (attested-delivery) |
+| 7 | Vuln disposition | `reusable-vex.yml` | `vexctl@v0.4.1` (go install) | OpenVEX JSON | `https://openvex.dev/ns/v0.2.0` | — | ✅ |
+| 8 | Build provenance | attested-delivery `sign-and-attest.yml` | `actions/attest-build-provenance@a2bbfa25…` / SLSA generator | SLSA provenance | `https://slsa.dev/provenance/v1` | — | ✅ |
+| 9 | Supply-chain posture | `reusable-scorecard.yml` | `ossf/scorecard-action@4eaacf05…` (v2.4.3) | SARIF + OSSF API | `https://zircote.github.io/attestations/scorecard/v1` | ⚠️ advisory | — |
+| 10 | Peer review | rulesets / branch protection / CODEOWNERS / Gitsign | config | reviews API; signed commits | n/a (config) | ✅ | — |
+| 11 | Load / perf (opt-in) | `reusable-k6.yml` | `grafana/setup-k6-action@db07bd97…` + `grafana/run-k6-action@de51a739…` | JSON summary + exit 99 | `https://zircote.github.io/attestations/k6-load/v1` | ⚠️ optional | ✅ seam |
+| 12 | DAST (opt-in) | `reusable-zap.yml` | `zaproxy/action-full-scan@3c583881…` (v0.13.0) | report (+ SARIF via AF) | `https://zircote.github.io/attestations/dast/v1` | ⚠️ optional | ✅ seam |
+
+The attestation seam itself — `reusable-attest-scan.yml` (`actions/attest@59d89421…`
+v4.1.0) — is what turns any evidence file in rows 1, 2, 4, 5, 9, 11, 12 into a
+signed, digest-bound claim.
+
+## SARIF hub
+
+CodeQL, OSV-Scanner, Trivy, Scorecard, and ZAP all normalize on SARIF 2.1.0, so
+every gate's findings converge on the one code-scanning Security tab. The
+code-scanning required status check fails a PR on any `error`/`critical`/`high`
+finding — that single check gates merge for rows 1, 2, 4, 5 at once.
+
+## Notes per gate
+
+- **CodeQL languages** — interpreted (`javascript-typescript`, `python`, `ruby`,
+  `actions`) run with `build-mode: none`; compiled (`c-cpp`, `csharp`, `go`,
+  `java-kotlin`, `swift`) need `autobuild`/`manual` and usually one call each.
+- **OSV-Scanner** is the SCA *second opinion* alongside Dependabot (free on all
+  plans, configured in `dependabot.yml`) and dependency review (PR gate).
+- **Trivy image scan** runs only when the caller passes `image-ref` (a digest).
+  IaC + license scan run on the repo filesystem unconditionally.
+- **ZAP SARIF** is an engine (Automation Framework) report, not a native action
+  input — emit via `cmd-options` and upload as a follow-on step if you want it
+  in code scanning. The action attaches an HTML/JSON report artifact by default.
+- **k6 / ZAP** require a running target; treat as opt-in.

--- a/.github/skills/gh-attested/references/limitations.md
+++ b/.github/skills/gh-attested/references/limitations.md
@@ -1,0 +1,43 @@
+# Honest limitations
+
+From `GITHUB-NATIVE-ATTESTED-QUALITY-GATES.md` §9, plus this skill's scope.
+
+- **CodeQL, secret scanning, and dependency review are free only on public
+  repos.** On private/internal repos they require licenses — GitHub Code
+  Security ($30/active committer/month: code scanning, premium Dependabot,
+  dependency review) and GitHub Secret Protection ($19/active committer/month:
+  secret scanning + push protection). The OSS Actions (Trivy, OSV-Scanner, ZAP,
+  Scorecard, Syft, vexctl, k6) close the gap *functionally* at only Actions-
+  compute cost, but Trivy is not a like-for-like CodeQL replacement (CodeQL's
+  dataflow depth is distinctive). **This skill targets the public-repo free
+  path.**
+
+- **GitHub provides no Kubernetes admission control.** It gates merges and
+  deployment jobs, not workload admission. The runtime verify-at-admission gate
+  is external (Kyverno / Sigstore policy-controller) and out of scope.
+
+- **No standard performance predicate.** k6 results ride a custom predicate
+  (`https://zircote.github.io/attestations/k6-load/v1`); SARIF and JUnit are
+  evidence formats, not predicate types.
+
+- **ZAP SARIF is an engine report, not a native action input.** Emit it via the
+  Automation Framework / `cmd-options` and upload as a separate step; the action
+  attaches an HTML/JSON report artifact by default.
+
+- **Third-party action supply-chain risk is real.** The Trivy `trivy-action`
+  compromise (CVE-2026-33634, March 2026 — 76 of 77 version tags force-pushed to
+  credential-stealing malware) is the cautionary case. Pin every third-party
+  action to a full 40-char commit SHA; run Scorecard's `Pinned-Dependencies` and
+  `Dangerous-Workflow` checks over your own workflows; `pin-check.yml` enforces
+  it in CI.
+
+- **Private-repo artifact attestations** route to GitHub's Sigstore instance
+  (Enterprise Cloud) rather than the public-good transparency log; verify
+  against the appropriate trusted root.
+
+- **A signed attestation proves a gate ran and recorded a verdict, not that it
+  passed.** The verifying policy must inspect the verdict field, and signer
+  identity must be pinned first (`--signer-workflow`).
+
+- **k6 and ZAP need a running target.** They are opt-in; wire them only when a
+  load script / deployed preview exists.

--- a/.github/skills/gh-attested/references/repo-config.md
+++ b/.github/skills/gh-attested/references/repo-config.md
@@ -1,0 +1,78 @@
+# Repo configuration — the safety contract
+
+Phase 3 provisions the GitHub-repo configuration the gates depend on. The rule
+is a hard split between what the skill **applies automatically** (idempotent,
+non-secret, reversible) and what it **only guides** (anything sensitive).
+
+## Apply automatically — but preview + confirm first
+
+Every mutation is shown as the exact `gh`/`gh api` command and **diffed against
+current state** before the first apply. Re-running must be a no-op. Nothing is
+force-applied; an ambiguous or failing state stops and reports. Tightening
+protection on an active branch requires an explicit confirm.
+
+Compose with the `gpm` skills rather than reinventing:
+`gpm-branch-protection`, `gpm-repo-settings`, `gpm-labels`.
+
+1. **Ruleset / branch protection** (`templates/ruleset.json`):
+   ```bash
+   gh api -X POST repos/<o>/<r>/rulesets --input templates/ruleset.json
+   # update an existing ruleset:
+   gh api -X PUT repos/<o>/<r>/rulesets/<id> --input templates/ruleset.json
+   ```
+   Required status checks (in-scope gate checks + `pin-check / pin-check`),
+   required reviews + CODEOWNERS, dismiss-stale, signed commits, linear history,
+   block force-push.
+
+2. **Repo settings**:
+   ```bash
+   gh api -X PATCH repos/<o>/<r> \
+     -F allow_auto_merge=true -F delete_branch_on_merge=true \
+     -F allow_squash_merge=true -F allow_merge_commit=false
+   ```
+
+3. **Native free-tier scanners** (public repos):
+   ```bash
+   # Code scanning default setup
+   gh api -X PATCH repos/<o>/<r>/code-scanning/default-setup -F state=configured
+   # Secret scanning + push protection
+   gh api -X PATCH repos/<o>/<r> \
+     -f 'security_and_analysis[secret_scanning][status]=enabled' \
+     -f 'security_and_analysis[secret_scanning_push_protection][status]=enabled'
+   ```
+   Report exactly what was toggled.
+
+4. **Committed files** (`dependabot.yml`, `CODEOWNERS`) — added via a PR, never
+   force-pushed.
+
+5. **Deploy environment**:
+   ```bash
+   gh api -X PUT repos/<o>/<r>/environments/production \
+     -F wait_timer=0 \
+     -f 'deployment_branch_policy[protected_branches]=true' \
+     -f 'deployment_branch_policy[custom_branch_policies]=false'
+   ```
+
+## Guide only — never written, never logged
+
+The skill emits the required **names** and the user-run command; it never reads,
+writes, commits, or prints a value.
+
+- **Secrets** (`gh secret set NAME` / `gh secret set NAME --env production`).
+  Most gates need **none** — keyless signing and all OSS scanners require no
+  secrets. Common optionals only: `GITLEAKS_LICENSE` (org gitleaks) and any
+  deploy credentials. See `templates/secrets-and-vars.md`.
+- **Variables** (`gh variable set NAME`) — non-secret config (severity
+  thresholds, ZAP target URLs). Offered as commands; applied only on explicit
+  per-item confirm.
+- **Environment required-reviewers** — human GitHub identities; a manual step,
+  the skill cannot choose reviewers.
+
+## The four safety rules (also in SKILL.md)
+
+1. Every config mutation is shown as a command and diffed before apply.
+2. Secrets/credentials are never read, written, committed, or logged — names and
+   the user-run command only.
+3. Nothing is force-applied; ambiguous/failing state stops and reports.
+4. Destructive changes (tightening protection on an active branch) need an
+   explicit confirm.

--- a/.github/skills/gh-attested/references/verification.md
+++ b/.github/skills/gh-attested/references/verification.md
@@ -1,0 +1,75 @@
+# Verifying quality-gate attestations
+
+Run these **independently from a workstation** against the published subject —
+in-pipeline success is not the acceptance test. `gh attestation verify` exits
+non-zero on any failure.
+
+`--signer-workflow` is **mandatory** under SLSA L3: the Fulcio SAN is the
+central signing workflow, not the source repo, so `--owner`/`--repo` alone fail.
+
+## Prerequisites
+
+```bash
+gh --version            # gh CLI authenticated
+gh attestation --help   # built in to recent gh
+```
+
+## Verify a single gate predicate
+
+```bash
+SUBJECT=oci://ghcr.io/zircote/app@sha256:<digest>   # or a file path / oci ref
+OWNER=zircote
+SIGNER=zircote/.github/.github/workflows/reusable-attest-scan.yml
+
+# SAST
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/sast/v1
+
+# SCA
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/sca/v1
+
+# Container vulnerability
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/container-scan/v1
+
+# IaC + license
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/iac-license/v1
+
+# Supply-chain posture
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/scorecard/v1
+
+# Vulnerability disposition (OpenVEX — standard predicate type)
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://openvex.dev/ns/v0.2.0
+```
+
+## Verify the build-provenance backbone (attested-delivery signer)
+
+```bash
+gh attestation verify "$SUBJECT" --owner "$OWNER" \
+  --signer-workflow zircote/.github/.github/workflows/sign-and-attest.yml \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+## Offline / air-gapped
+
+```bash
+gh attestation trusted-root > trusted_root.jsonl
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --bundle attestation.sigstore.json --custom-trusted-root trusted_root.jsonl
+```
+
+## Read the verdict, not just the signature
+
+A successful `verify` proves the attestation is authentic and bound to the
+subject — **not** that the gate passed. Inspect the predicate body to confirm
+the recorded verdict:
+
+```bash
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/sast/v1 \
+  --format json | jq '.[0].verificationResult.statement.predicate'
+```

--- a/.github/skills/gh-attested/references/verification.md
+++ b/.github/skills/gh-attested/references/verification.md
@@ -16,35 +16,42 @@ gh attestation --help   # built in to recent gh
 
 ## Verify a single gate predicate
 
+**Each predicate is verified against the workflow that actually signed it** —
+the "Signed by" column in
+[`docs/reference/attestation-predicates/`](../../../../docs/reference/attestation-predicates/README.md)
+is the source of truth. The seam (`reusable-attest-scan.yml`) signs the SARIF
+gates; **OpenVEX self-signs in `reusable-vex.yml` and k6 self-signs in
+`reusable-k6.yml`** (each runs its own `actions/attest`, so under SLSA L3 its
+Fulcio SAN is itself, not the seam). Pin `--signer-workflow` accordingly — one
+signer per command.
+
 ```bash
 SUBJECT=oci://ghcr.io/zircote/app@sha256:<digest>   # or a file path / oci ref
 OWNER=zircote
-SIGNER=zircote/.github/.github/workflows/reusable-attest-scan.yml
+SEAM=zircote/.github/.github/workflows/reusable-attest-scan.yml
+VEX_SIGNER=zircote/.github/.github/workflows/reusable-vex.yml
+K6_SIGNER=zircote/.github/.github/workflows/reusable-k6.yml
 
-# SAST
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
-  --predicate-type https://zircote.github.io/attestations/sast/v1
+# Seam-signed gates (SAST, SCA, container, IaC+license, posture, DAST)
+for pt in sast sca container-scan iac-license scorecard dast; do
+  gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SEAM" \
+    --predicate-type "https://zircote.github.io/attestations/${pt}/v1"
+done
 
-# SCA
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
-  --predicate-type https://zircote.github.io/attestations/sca/v1
-
-# Container vulnerability
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
-  --predicate-type https://zircote.github.io/attestations/container-scan/v1
-
-# IaC + license
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
-  --predicate-type https://zircote.github.io/attestations/iac-license/v1
-
-# Supply-chain posture
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
-  --predicate-type https://zircote.github.io/attestations/scorecard/v1
-
-# Vulnerability disposition (OpenVEX — standard predicate type)
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+# Vulnerability disposition (OpenVEX — self-signed by reusable-vex.yml)
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$VEX_SIGNER" \
   --predicate-type https://openvex.dev/ns/v0.2.0
+
+# Load / performance (k6 — self-signed by reusable-k6.yml)
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$K6_SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/k6-load/v1
 ```
+
+> The seam-signed SARIF predicates verify once the gate jobs upload their
+> evidence to `reusable-attest-scan.yml` (see `attestation-seam.md`); OpenVEX and
+> k6 sign inline today. The `--signer-workflow` pins below are verified by
+> reasoning about the SLSA L3 certificate identity, not by a live `gh
+> attestation verify` run in this repo.
 
 ## Verify the build-provenance backbone (attested-delivery signer)
 
@@ -58,7 +65,7 @@ gh attestation verify "$SUBJECT" --owner "$OWNER" \
 
 ```bash
 gh attestation trusted-root > trusted_root.jsonl
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SEAM" \
   --bundle attestation.sigstore.json --custom-trusted-root trusted_root.jsonl
 ```
 
@@ -69,7 +76,7 @@ subject — **not** that the gate passed. Inspect the predicate body to confirm
 the recorded verdict:
 
 ```bash
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SEAM" \
   --predicate-type https://zircote.github.io/attestations/sast/v1 \
   --format json | jq '.[0].verificationResult.statement.predicate'
 ```

--- a/.github/skills/gh-attested/templates/CODEOWNERS
+++ b/.github/skills/gh-attested/templates/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS — required by the ruleset's "require code owner review" rule.
+# Replace __org__ and the team/handles with the target's owners.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything
+*                       @__org__/maintainers
+
+# CI / supply-chain config needs owner review (these gate every other change)
+/.github/workflows/     @__org__/maintainers
+/.github/dependabot.yml @__org__/maintainers
+/.vex/                  @__org__/maintainers

--- a/.github/skills/gh-attested/templates/README.md
+++ b/.github/skills/gh-attested/templates/README.md
@@ -1,0 +1,52 @@
+# Templates — attested quality gates, parameterized
+
+`__org__`-parameterized copies of the central reusable workflows, plus the
+caller and repo-configuration artifacts. The skill is self-contained:
+materializing the gate suite needs nothing beyond this directory.
+
+## Workflow templates
+
+`reusable-{sast-codeql,sca-osv,trivy,scorecard,vex,k6,zap,attest-scan,verify-gates}.yml`
+are byte-for-byte copies of the live central workflows in
+`zircote/.github/.github/workflows/`, with the single token `__org__`
+substituted for the owner.
+
+## Materialization
+
+1. **Central repo** (one-time, if not already live): copy the `reusable-*.yml`
+   into the org's central `.github` repo's `.github/workflows/`, substitute the
+   token, commit to the default branch, record the SHA.
+   ```sh
+   sed -i '' 's/__org__/MyOrg/g' .github/workflows/reusable-*.yml
+   ```
+   Public central repos are callable by anyone; private/internal ones need
+   `gh api -X PUT repos/<owner>/.github/actions/permissions/access -f access_level=organization`.
+
+2. **Target repo** (per repo being onboarded):
+   - Copy `quality-gates-caller.yml` → `.github/workflows/quality-gates.yml`,
+     substitute `__org__`, pin every `@<sha>` to the central repo's commit SHA,
+     edit `languages:` and gate inputs for the repo.
+   - Copy `dependabot.yml` and `CODEOWNERS` (substitute `__org__`).
+   - Apply `ruleset.json` via `gh api -X POST repos/<o>/<r>/rulesets --input ruleset.json`
+     after a diff-against-current preview (see references/repo-config.md).
+   - Append `SECURITY-snippet.md` to the repo's `SECURITY.md`.
+   - Read `secrets-and-vars.md` and set any optional secrets/variables yourself.
+
+## Drift
+
+These templates are the canonical parameterized source. If the live central
+workflows change, regenerate the copies:
+```sh
+for wf in reusable-sast-codeql reusable-sca-osv reusable-trivy reusable-scorecard \
+          reusable-vex reusable-k6 reusable-zap reusable-attest-scan reusable-verify-gates; do
+  sed 's/zircote/__org__/g' ../../../workflows/${wf}.yml > ${wf}.yml
+done
+```
+So template and live workflow never drift.
+
+## Provenance and freshness
+
+Every third-party action is pinned to a full commit SHA with the version as a
+comment. `aquasecurity/trivy-action` is pinned to a maintainer-signed commit
+dated after the March 2026 tag-compromise (CVE-2026-33634) — never replace it
+with a tag.

--- a/.github/skills/gh-attested/templates/README.md
+++ b/.github/skills/gh-attested/templates/README.md
@@ -17,7 +17,8 @@ substituted for the owner.
    into the org's central `.github` repo's `.github/workflows/`, substitute the
    token, commit to the default branch, record the SHA.
    ```sh
-   sed -i '' 's/__org__/MyOrg/g' .github/workflows/reusable-*.yml
+   # cross-platform in-place edit (GNU and BSD/macOS `sed -i` differ; perl is portable)
+   perl -pi -e 's/__org__/MyOrg/g' .github/workflows/reusable-*.yml
    ```
    Public central repos are callable by anyone; private/internal ones need
    `gh api -X PUT repos/<owner>/.github/actions/permissions/access -f access_level=organization`.

--- a/.github/skills/gh-attested/templates/SECURITY-snippet.md
+++ b/.github/skills/gh-attested/templates/SECURITY-snippet.md
@@ -9,17 +9,22 @@ via GitHub keyless signing. Verify them from any workstation with the `gh` CLI.
 `--signer-workflow` is required: signing runs in a central reusable workflow, so
 the certificate identity (SLSA L3) is the signer, not this repo.
 
+Each predicate is pinned to the workflow that actually signed it: the seam
+(`reusable-attest-scan.yml`) signs the SARIF gates; OpenVEX self-signs in
+`reusable-vex.yml`; k6 self-signs in `reusable-k6.yml`.
+
 ```bash
 SUBJECT=oci://ghcr.io/__org__/app@sha256:<digest>   # or your release artifact ref
 OWNER=__org__
-SIGNER=__org__/.github/.github/workflows/reusable-attest-scan.yml
+SEAM=__org__/.github/.github/workflows/reusable-attest-scan.yml
 
-# Example: verify the SAST gate attestation
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+# Seam-signed gate (SAST shown; other SARIF gates: swap the predicate-type)
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SEAM" \
   --predicate-type https://__org__.github.io/attestations/sast/v1
 
-# Vulnerability disposition (OpenVEX — standard predicate)
-gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+# Vulnerability disposition (OpenVEX — self-signed by reusable-vex.yml)
+gh attestation verify "$SUBJECT" --owner "$OWNER" \
+  --signer-workflow __org__/.github/.github/workflows/reusable-vex.yml \
   --predicate-type https://openvex.dev/ns/v0.2.0
 ```
 

--- a/.github/skills/gh-attested/templates/SECURITY-snippet.md
+++ b/.github/skills/gh-attested/templates/SECURITY-snippet.md
@@ -1,0 +1,28 @@
+<!-- Append to the target repo's SECURITY.md. Replace __org__ with the owner. -->
+
+## Verifying Quality-Gate Attestations
+
+Each CI quality gate (SAST, SCA, container/IaC/license scan, supply-chain
+posture, vulnerability disposition) records a signed, digest-bound attestation
+via GitHub keyless signing. Verify them from any workstation with the `gh` CLI.
+
+`--signer-workflow` is required: signing runs in a central reusable workflow, so
+the certificate identity (SLSA L3) is the signer, not this repo.
+
+```bash
+SUBJECT=oci://ghcr.io/__org__/app@sha256:<digest>   # or your release artifact ref
+OWNER=__org__
+SIGNER=__org__/.github/.github/workflows/reusable-attest-scan.yml
+
+# Example: verify the SAST gate attestation
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://__org__.github.io/attestations/sast/v1
+
+# Vulnerability disposition (OpenVEX — standard predicate)
+gh attestation verify "$SUBJECT" --owner "$OWNER" --signer-workflow "$SIGNER" \
+  --predicate-type https://openvex.dev/ns/v0.2.0
+```
+
+A successful verification proves the attestation is authentic and bound to the
+artifact — inspect the predicate body (`--format json | jq …`) to read the
+gate's recorded verdict.

--- a/.github/skills/gh-attested/templates/dependabot.yml
+++ b/.github/skills/gh-attested/templates/dependabot.yml
@@ -1,0 +1,16 @@
+# Keep the SHA pins in the quality-gate workflows fresh. Dependabot's
+# github-actions ecosystem opens PRs that bump pinned SHAs (and their version
+# comments) as new releases ship — including the central reusable workflow pins
+# (action-deps) when they are referenced by SHA.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci

--- a/.github/skills/gh-attested/templates/quality-gates-caller.yml
+++ b/.github/skills/gh-attested/templates/quality-gates-caller.yml
@@ -14,7 +14,8 @@ name: quality-gates
 
 on:
   push:
-    branches: [main]
+    branches: [main]   # CHANGE to YOUR repo's default branch (main / master / trunk);
+                       # confirm via: gh api repos/<owner>/<repo> --jq .default_branch
   pull_request:
 
 permissions:

--- a/.github/skills/gh-attested/templates/quality-gates-caller.yml
+++ b/.github/skills/gh-attested/templates/quality-gates-caller.yml
@@ -1,0 +1,79 @@
+# Thin caller — wire a repo's merge-time quality gates to the central reusables.
+#
+# Copy to the TARGET repo's .github/workflows/quality-gates.yml, replace
+# __org__ with the owner, and pin every @<sha> to the full 40-char commit SHA of
+# the central repo (Dependabot's github-actions ecosystem keeps them fresh).
+#
+# This is the universal merge-time core (SAST + SCA + posture + IaC/license +
+# pin-check). For the DEPLOY-TIME attestation seam (sign each gate's verdict and
+# fail-closed verify before shipping), see references/attestation-seam.md and
+# references/enforcement.md — the seam consumes an evidence artifact, so the gate
+# job must upload its SARIF (or call the scan inline) before reusable-attest-scan.
+
+name: quality-gates
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  sast:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: __org__/.github/.github/workflows/reusable-sast-codeql.yml@<sha>
+    with:
+      languages: 'javascript-typescript'   # edit per repo; compiled langs need build-mode
+
+  sca:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      pull-requests: write
+    uses: __org__/.github/.github/workflows/reusable-sca-osv.yml@<sha>
+    with:
+      fail-on-severity: high
+
+  posture:
+    if: github.event_name == 'push'
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    uses: __org__/.github/.github/workflows/reusable-scorecard.yml@<sha>
+
+  trivy:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: __org__/.github/.github/workflows/reusable-trivy.yml@<sha>
+    with:
+      scan-iac: true
+      # image-ref: ghcr.io/__org__/app@sha256:<digest>   # add to scan a built image
+
+  pin-check:
+    permissions:
+      contents: read
+    uses: __org__/.github/.github/workflows/pin-check.yml@<sha>
+
+  # ---------------------------------------------------------------------------
+  # Opt-in gates (need a running target) — uncomment when applicable:
+  #
+  # load:
+  #   permissions: { id-token: write, attestations: write, contents: read }
+  #   uses: __org__/.github/.github/workflows/reusable-k6.yml@<sha>
+  #   with: { script-path: tests/load.js }
+  #
+  # dast:
+  #   permissions: { contents: read }
+  #   uses: __org__/.github/.github/workflows/reusable-zap.yml@<sha>
+  #   with: { target: https://staging.example.com }
+  # ---------------------------------------------------------------------------

--- a/.github/skills/gh-attested/templates/reusable-attest-scan.yml
+++ b/.github/skills/gh-attested/templates/reusable-attest-scan.yml
@@ -1,0 +1,84 @@
+# Reusable workflow: the attestation "seam".
+#
+# Turns any quality-gate's evidence file (a scanner's SARIF/JSON, a load-test
+# summary, an OpenVEX document, ...) into a signed, digest-bound in-toto
+# attestation via GitHub keyless signing (`actions/attest`, custom predicate).
+# A clean result in the Security tab is *evidence*; this attestation is the
+# enforceable, verifiable *claim* — bound to a subject by digest and signed by
+# this central workflow's OIDC identity (Sigstore Public Good for public repos).
+#
+# Verification (see SECURITY.md / gh-attested skill references/verification.md):
+#   gh attestation verify <subject> --owner <owner> \
+#     --predicate-type <predicate-type> \
+#     --signer-workflow <owner>/.github/.github/workflows/reusable-attest-scan.yml
+#
+# Security note: only workflow_call inputs (controlled by the caller) and the
+# downloaded evidence artifact are used. No untrusted input reaches a shell.
+#
+# Usage:
+#   jobs:
+#     attest-sast:
+#       needs: [sast]
+#       permissions:
+#         id-token: write
+#         attestations: write
+#         contents: read
+#       uses: __org__/.github/.github/workflows/reusable-attest-scan.yml@<sha>
+#       with:
+#         subject-name: my-app
+#         subject-digest: ${{ needs.build.outputs.digest }}   # sha256:...
+#         predicate-type: https://__org__.github.io/attestations/sast/v1
+#         predicate-artifact: codeql-sarif
+#         predicate-filename: results.sarif
+
+name: attest-scan
+
+on:
+  workflow_call:
+    inputs:
+      subject-name:
+        description: 'Logical subject name (image repo, package name, or artifact label)'
+        required: true
+        type: string
+      subject-digest:
+        description: 'Subject digest the predicate is bound to (sha256:...)'
+        required: true
+        type: string
+      predicate-type:
+        description: 'URI identifying the predicate type (e.g. https://openvex.dev/ns/v0.2.0)'
+        required: true
+        type: string
+      predicate-artifact:
+        description: 'Name of the uploaded artifact containing the evidence file'
+        required: true
+        type: string
+      predicate-filename:
+        description: 'Evidence filename within the artifact (e.g. results.sarif)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  attest:
+    name: attest
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # keyless Sigstore signing
+      attestations: write    # persist the GitHub artifact attestation
+      contents: read
+    steps:
+      - name: Download evidence artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.predicate-artifact }}
+          path: predicate
+
+      - name: Attest evidence as a signed custom predicate
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+          predicate-type: ${{ inputs.predicate-type }}
+          predicate-path: predicate/${{ inputs.predicate-filename }}

--- a/.github/skills/gh-attested/templates/reusable-k6.yml
+++ b/.github/skills/gh-attested/templates/reusable-k6.yml
@@ -1,0 +1,81 @@
+# Reusable workflow: Grafana k6 load / performance gate (conditional, opt-in).
+#
+# The gate is k6's thresholds — pass/fail criteria on test metrics. On a
+# threshold breach k6 exits 99 (ThresholdsHaveFailed), failing the job. The
+# JSON summary is optionally signed as a custom performance attestation (there
+# is no standard performance predicate type).
+#
+# The caller is responsible for starting/targeting the system under test; the
+# k6 script encodes the target URL and thresholds.
+#
+# Usage:
+#   jobs:
+#     load:
+#       permissions:
+#         id-token: write
+#         attestations: write
+#         contents: read
+#       uses: __org__/.github/.github/workflows/reusable-k6.yml@<sha>
+#       with:
+#         script-path: tests/load.js
+#         attest: true
+#         subject-name: my-app
+#         subject-digest: ${{ needs.build.outputs.digest }}
+
+name: k6
+
+on:
+  workflow_call:
+    inputs:
+      script-path:
+        description: 'Path to the k6 test script'
+        required: true
+        type: string
+      attest:
+        description: 'Sign the k6 summary as a custom performance attestation'
+        required: false
+        type: boolean
+        default: false
+      subject-name:
+        description: 'Subject name for the attestation (required when attest=true)'
+        required: false
+        type: string
+        default: ''
+      subject-digest:
+        description: 'Subject digest for the attestation (required when attest=true)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  load:
+    name: load
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up k6
+        uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
+
+      - name: Run k6 load test
+        uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
+        with:
+          path: ${{ inputs.script-path }}
+          flags: --summary-export=k6-summary.json
+
+      - name: Attest performance summary
+        if: ${{ inputs.attest && inputs.subject-digest != '' }}
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+          predicate-type: https://__org__.github.io/attestations/k6-load/v1
+          predicate-path: k6-summary.json

--- a/.github/skills/gh-attested/templates/reusable-k6.yml
+++ b/.github/skills/gh-attested/templates/reusable-k6.yml
@@ -62,6 +62,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Fail fast before the load run: attest=true with no subject would
+      # otherwise silently skip the attestation and still report success.
+      - name: Validate attestation inputs
+        if: ${{ inputs.attest }}
+        env:
+          SUBJECT_NAME: ${{ inputs.subject-name }}
+          SUBJECT_DIGEST: ${{ inputs.subject-digest }}
+        run: |
+          if [ -z "${SUBJECT_NAME}" ] || [ -z "${SUBJECT_DIGEST}" ]; then
+            echo "::error::attest=true requires subject-name and subject-digest"
+            exit 1
+          fi
+
       - name: Set up k6
         uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
 
@@ -72,7 +85,7 @@ jobs:
           flags: --summary-export=k6-summary.json
 
       - name: Attest performance summary
-        if: ${{ inputs.attest && inputs.subject-digest != '' }}
+        if: ${{ inputs.attest }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ inputs.subject-name }}

--- a/.github/skills/gh-attested/templates/reusable-sast-codeql.yml
+++ b/.github/skills/gh-attested/templates/reusable-sast-codeql.yml
@@ -1,0 +1,77 @@
+# Reusable workflow: SAST via CodeQL code scanning.
+#
+# CodeQL builds a database (AST + data-flow + control-flow graphs) and runs
+# security queries, emitting SARIF 2.1.0 into the GitHub code-scanning hub. On
+# a pull request the "Code scanning results" check fails on any error/critical/
+# high finding — wire it as a required status check to make it a merge gate.
+# Free for public repositories by default (GitHub Advanced Security).
+#
+# Compiled languages (c-cpp, csharp, go, java-kotlin, swift) generally need a
+# build: pass `build-mode: autobuild` or `build-mode: manual` and call once per
+# language. Interpreted languages (javascript-typescript, python, ruby,
+# actions) work with `build-mode: none`.
+#
+# Usage:
+#   jobs:
+#     sast:
+#       permissions:
+#         security-events: write
+#         contents: read
+#         actions: read
+#       uses: __org__/.github/.github/workflows/reusable-sast-codeql.yml@<sha>
+#       with:
+#         languages: 'javascript-typescript,python'
+
+name: sast-codeql
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        description: 'Comma-separated CodeQL languages (e.g. javascript-typescript,python)'
+        required: true
+        type: string
+      build-mode:
+        description: 'CodeQL build mode: none | autobuild | manual'
+        required: false
+        type: string
+        default: 'none'
+      config-file:
+        description: 'Optional path to a codeql-config.yml'
+        required: false
+        type: string
+        default: ''
+      queries:
+        description: 'Optional query suite (e.g. security-extended)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      contents: read
+      actions: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          languages: ${{ inputs.languages }}
+          build-mode: ${{ inputs.build-mode }}
+          config-file: ${{ inputs.config-file }}
+          queries: ${{ inputs.queries }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          category: '/language:${{ inputs.languages }}'

--- a/.github/skills/gh-attested/templates/reusable-sca-osv.yml
+++ b/.github/skills/gh-attested/templates/reusable-sca-osv.yml
@@ -1,0 +1,73 @@
+# Reusable workflow: SCA via OSV-Scanner + GitHub dependency review.
+#
+# Two complementary free layers (Dependabot alerts are the third, configured at
+# the repo level and outside this workflow):
+#   - OSV-Scanner (Google, Apache-2.0): an independent second opinion against
+#     the OSV database across lockfiles and ecosystems; uploads SARIF to the
+#     code-scanning hub.
+#   - dependency-review-action: the PR merge gate — fails the check when a PR
+#     introduces a vulnerable dependency or a disallowed license. Public-repo
+#     free.
+#
+# Usage:
+#   jobs:
+#     sca:
+#       permissions:
+#         actions: read
+#         contents: read
+#         security-events: write
+#         pull-requests: write
+#       uses: __org__/.github/.github/workflows/reusable-sca-osv.yml@<sha>
+#       with:
+#         fail-on-severity: high
+
+name: sca-osv
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: 'dependency-review threshold: low | moderate | high | critical'
+        required: false
+        type: string
+        default: 'high'
+      scan-args:
+        description: 'OSV-Scanner arguments'
+        required: false
+        type: string
+        default: |-
+          --recursive
+          ./
+
+permissions:
+  contents: read
+
+jobs:
+  # OSV-Scanner ships an official reusable workflow that scans, generates SARIF,
+  # and uploads it to code scanning. Pinned to the repo's release SHA.
+  osv-scan:
+    name: osv-scanner
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: ${{ inputs.scan-args }}
+
+  dependency-review:
+    name: dependency-review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+          comment-summary-in-pr: on-failure

--- a/.github/skills/gh-attested/templates/reusable-scorecard.yml
+++ b/.github/skills/gh-attested/templates/reusable-scorecard.yml
@@ -1,0 +1,62 @@
+# Reusable workflow: OpenSSF Scorecard — supply-chain posture.
+#
+# Scores 0-10 heuristics (Branch-Protection, Code-Review, Token-Permissions,
+# Dangerous-Workflow, Pinned-Dependencies, Signed-Releases, ...) and uploads
+# SARIF to the code-scanning hub. With publish-results: true the run is
+# published to the OpenSSF REST API (a public posture attestation + badge),
+# which requires id-token: write.
+#
+# Recommended trigger in the caller: branch_protection_rule, schedule (weekly),
+# and push to the default branch.
+#
+# Usage:
+#   jobs:
+#     scorecard:
+#       permissions:
+#         security-events: write
+#         id-token: write
+#         contents: read
+#         actions: read
+#       uses: __org__/.github/.github/workflows/reusable-scorecard.yml@<sha>
+
+name: scorecard
+
+on:
+  workflow_call:
+    inputs:
+      publish-results:
+        description: 'Publish results to the OpenSSF API (public repos only)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF
+      id-token: write          # publish to OpenSSF API
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: ${{ inputs.publish-results }}
+
+      - name: Upload Scorecard SARIF
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: scorecard.sarif
+          category: scorecard

--- a/.github/skills/gh-attested/templates/reusable-trivy.yml
+++ b/.github/skills/gh-attested/templates/reusable-trivy.yml
@@ -1,0 +1,107 @@
+# Reusable workflow: Trivy — container image, IaC misconfiguration, and license.
+#
+# Complements sbom-and-scan.yml (SBOM + Grype). Trivy adds:
+#   - image vulnerability scan (when image-ref is set), fail-closed on severity;
+#   - IaC misconfiguration scan of the repo (Docker/K8s/Terraform/CloudFormation);
+#   - license scan (Forbidden->CRITICAL, Restricted->HIGH).
+# All findings normalize on SARIF and land in the code-scanning hub, so the
+# code-scanning required check is the merge gate for the repo scan; the image
+# scan additionally fails the job on findings at/above `severity`.
+#
+# SECURITY: aquasecurity/trivy-action is pinned to a full commit SHA. In
+# March 2026 (CVE-2026-33634) an attacker force-pushed 76 of 77 trivy-action
+# tags to credential-stealing malware; tag references are unsafe. Never replace
+# this SHA with a tag.
+#
+# Usage:
+#   jobs:
+#     trivy:
+#       permissions:
+#         contents: read
+#         security-events: write
+#         actions: read
+#       uses: __org__/.github/.github/workflows/reusable-trivy.yml@<sha>
+#       with:
+#         image-ref: ghcr.io/__org__/app@sha256:...   # omit to scan repo only
+
+name: trivy
+
+on:
+  workflow_call:
+    inputs:
+      image-ref:
+        description: 'Image to scan by digest (empty = skip image scan)'
+        required: false
+        type: string
+        default: ''
+      severity:
+        description: 'Severities to report/fail on'
+        required: false
+        type: string
+        default: 'HIGH,CRITICAL'
+      scan-iac:
+        description: 'Scan repo for IaC misconfiguration + license issues'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  iac-license:
+    name: iac-license
+    if: ${{ inputs.scan-iac }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Trivy IaC + license scan (filesystem)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: misconfig,license
+          format: sarif
+          output: trivy-iac-license.sarif
+          severity: ${{ inputs.severity }}
+          exit-code: '0'   # report to code scanning; the code-scanning check is the gate
+
+      - name: Upload IaC + license SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: trivy-iac-license.sarif
+          category: trivy-iac-license
+
+  image:
+    name: image
+    if: ${{ inputs.image-ref != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
+    steps:
+      - name: Trivy image vulnerability scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ inputs.image-ref }}
+          format: sarif
+          output: trivy-image.sarif
+          severity: ${{ inputs.severity }}
+          exit-code: '1'   # fail-closed on image vulnerabilities
+
+      - name: Upload image SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/.github/skills/gh-attested/templates/reusable-verify-gates.yml
+++ b/.github/skills/gh-attested/templates/reusable-verify-gates.yml
@@ -3,13 +3,20 @@
 # Runs `gh attestation verify` against a subject for each required predicate
 # type. Any verification failure exits non-zero, so placing this job in a
 # deploy job's `needs:` halts an unverified or improperly-signed artifact
-# before it ships. Under SLSA L3 the signer identity is the central signing
-# workflow (the Fulcio SAN), so --signer-workflow is mandatory; --owner alone
-# is insufficient.
+# before it ships. Under SLSA L3 the signer identity is the workflow that ran
+# `actions/attest` (the Fulcio SAN), so --signer-workflow is mandatory; --owner
+# alone is insufficient.
+#
+# IMPORTANT: this workflow verifies ONE signer per invocation. Different
+# predicates are signed by different workflows — the seam
+# (reusable-attest-scan.yml) signs the SARIF gates, while OpenVEX self-signs in
+# reusable-vex.yml and k6 in reusable-k6.yml. Call this workflow once per signer
+# group; mixing predicates from different signers fails closed on a VALID
+# artifact. See docs/reference/attestation-predicates/ ("Signed by").
 #
 # Usage:
 #   jobs:
-#     verify:
+#     verify-seam:
 #       permissions:
 #         contents: read
 #         attestations: read
@@ -21,9 +28,20 @@
 #         signer-workflow: __org__/.github/.github/workflows/reusable-attest-scan.yml
 #         predicate-types: |-
 #           https://__org__.github.io/attestations/sast/v1
-#           https://openvex.dev/ns/v0.2.0
+#           https://__org__.github.io/attestations/sca/v1
+#     verify-vex:                          # OpenVEX is signed by reusable-vex.yml
+#       permissions:
+#         contents: read
+#         attestations: read
+#         packages: read
+#       uses: __org__/.github/.github/workflows/reusable-verify-gates.yml@<sha>
+#       with:
+#         subject-ref: oci://ghcr.io/__org__/app@sha256:...
+#         owner: __org__
+#         signer-workflow: __org__/.github/.github/workflows/reusable-vex.yml
+#         predicate-types: https://openvex.dev/ns/v0.2.0
 #     deploy:
-#       needs: [verify]
+#       needs: [verify-seam, verify-vex]
 #       ...
 
 name: verify-gates
@@ -40,7 +58,7 @@ on:
         required: true
         type: string
       signer-workflow:
-        description: 'Signing workflow identity (owner/.github/.github/workflows/reusable-attest-scan.yml)'
+        description: 'The single signer for ALL predicate-types in this call (e.g. reusable-attest-scan.yml for seam-signed gates, reusable-vex.yml for OpenVEX). One signer per invocation.'
         required: true
         type: string
       predicate-types:

--- a/.github/skills/gh-attested/templates/reusable-verify-gates.yml
+++ b/.github/skills/gh-attested/templates/reusable-verify-gates.yml
@@ -11,7 +11,6 @@
 #   jobs:
 #     verify:
 #       permissions:
-#         id-token: write
 #         contents: read
 #         attestations: read
 #         packages: read
@@ -45,10 +44,9 @@ on:
         required: true
         type: string
       predicate-types:
-        description: 'Newline- or whitespace-separated predicate type URIs to require'
-        required: false
+        description: 'Newline- or whitespace-separated predicate type URIs to require (at least one)'
+        required: true
         type: string
-        default: ''
 
 permissions:
   contents: read
@@ -58,7 +56,6 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       attestations: read
       packages: read
@@ -72,18 +69,19 @@ jobs:
           PREDICATE_TYPES: ${{ inputs.predicate-types }}
         run: |
           set -euo pipefail
+          # Fail closed: refuse to "verify" with no required predicate. An empty
+          # list would otherwise let a deploy proceed against no specific gate.
           if [ -z "${PREDICATE_TYPES//[[:space:]]/}" ]; then
-            echo "Verifying ${SUBJECT} (default provenance predicate)"
-            gh attestation verify "${SUBJECT}" --owner "${OWNER}" --signer-workflow "${SIGNER}"
-          else
-            failed=0
-            for pt in ${PREDICATE_TYPES}; do
-              echo "Verifying ${SUBJECT} against predicate ${pt}"
-              if ! gh attestation verify "${SUBJECT}" --owner "${OWNER}" \
-                    --signer-workflow "${SIGNER}" --predicate-type "${pt}"; then
-                echo "::error::verification failed for predicate ${pt}"
-                failed=1
-              fi
-            done
-            exit "${failed}"
+            echo "::error::predicate-types is required and must name at least one predicate URI (fail closed)"
+            exit 1
           fi
+          failed=0
+          for pt in ${PREDICATE_TYPES}; do
+            echo "Verifying ${SUBJECT} against predicate ${pt}"
+            if ! gh attestation verify "${SUBJECT}" --owner "${OWNER}" \
+                  --signer-workflow "${SIGNER}" --predicate-type "${pt}"; then
+              echo "::error::verification failed for predicate ${pt}"
+              failed=1
+            fi
+          done
+          exit "${failed}"

--- a/.github/skills/gh-attested/templates/reusable-verify-gates.yml
+++ b/.github/skills/gh-attested/templates/reusable-verify-gates.yml
@@ -1,0 +1,89 @@
+# Reusable workflow: fail-closed verification of gate attestations.
+#
+# Runs `gh attestation verify` against a subject for each required predicate
+# type. Any verification failure exits non-zero, so placing this job in a
+# deploy job's `needs:` halts an unverified or improperly-signed artifact
+# before it ships. Under SLSA L3 the signer identity is the central signing
+# workflow (the Fulcio SAN), so --signer-workflow is mandatory; --owner alone
+# is insufficient.
+#
+# Usage:
+#   jobs:
+#     verify:
+#       permissions:
+#         id-token: write
+#         contents: read
+#         attestations: read
+#         packages: read
+#       uses: __org__/.github/.github/workflows/reusable-verify-gates.yml@<sha>
+#       with:
+#         subject-ref: oci://ghcr.io/__org__/app@sha256:...
+#         owner: __org__
+#         signer-workflow: __org__/.github/.github/workflows/reusable-attest-scan.yml
+#         predicate-types: |-
+#           https://__org__.github.io/attestations/sast/v1
+#           https://openvex.dev/ns/v0.2.0
+#     deploy:
+#       needs: [verify]
+#       ...
+
+name: verify-gates
+
+on:
+  workflow_call:
+    inputs:
+      subject-ref:
+        description: 'Subject to verify (oci://...@sha256 or a file path)'
+        required: true
+        type: string
+      owner:
+        description: 'Repository owner that produced the attestations'
+        required: true
+        type: string
+      signer-workflow:
+        description: 'Signing workflow identity (owner/.github/.github/workflows/reusable-attest-scan.yml)'
+        required: true
+        type: string
+      predicate-types:
+        description: 'Newline- or whitespace-separated predicate type URIs to require'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: read
+      packages: read
+    steps:
+      - name: Verify gate attestations (fail-closed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SUBJECT: ${{ inputs.subject-ref }}
+          OWNER: ${{ inputs.owner }}
+          SIGNER: ${{ inputs.signer-workflow }}
+          PREDICATE_TYPES: ${{ inputs.predicate-types }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PREDICATE_TYPES//[[:space:]]/}" ]; then
+            echo "Verifying ${SUBJECT} (default provenance predicate)"
+            gh attestation verify "${SUBJECT}" --owner "${OWNER}" --signer-workflow "${SIGNER}"
+          else
+            failed=0
+            for pt in ${PREDICATE_TYPES}; do
+              echo "Verifying ${SUBJECT} against predicate ${pt}"
+              if ! gh attestation verify "${SUBJECT}" --owner "${OWNER}" \
+                    --signer-workflow "${SIGNER}" --predicate-type "${pt}"; then
+                echo "::error::verification failed for predicate ${pt}"
+                failed=1
+              fi
+            done
+            exit "${failed}"
+          fi

--- a/.github/skills/gh-attested/templates/reusable-vex.yml
+++ b/.github/skills/gh-attested/templates/reusable-vex.yml
@@ -1,0 +1,90 @@
+# Reusable workflow: OpenVEX vulnerability disposition.
+#
+# A clean scan is rarely zero findings. An OpenVEX document (maintained in the
+# repo) records per-vulnerability status (not_affected / affected / fixed /
+# under_investigation) so the deploy gate can enforce "no UNDISPOSITIONED
+# high/critical vulnerabilities" rather than "zero findings". This workflow
+# normalizes the document with `vexctl merge` and signs it as an OpenVEX
+# attestation bound to the artifact digest.
+#
+# vexctl is installed via `go install` pinned to a module version (immutable via
+# the Go checksum database) — there is no official vexctl GitHub Action.
+#
+# Usage:
+#   jobs:
+#     vex:
+#       needs: [build]
+#       permissions:
+#         id-token: write
+#         attestations: write
+#         contents: read
+#       uses: __org__/.github/.github/workflows/reusable-vex.yml@<sha>
+#       with:
+#         subject-name: ghcr.io/__org__/app
+#         subject-digest: ${{ needs.build.outputs.digest }}
+#         vex-path: .vex/openvex.json
+
+name: vex
+
+on:
+  workflow_call:
+    inputs:
+      subject-name:
+        description: 'Subject the OpenVEX statement is bound to'
+        required: true
+        type: string
+      subject-digest:
+        description: 'Subject digest (sha256:...)'
+        required: true
+        type: string
+      vex-path:
+        description: 'Path to the OpenVEX document in the repository'
+        required: false
+        type: string
+        default: '.vex/openvex.json'
+      vexctl-version:
+        description: 'vexctl module version to install'
+        required: false
+        type: string
+        default: 'v0.4.1'
+
+permissions:
+  contents: read
+
+jobs:
+  attest-vex:
+    name: attest-vex
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+
+      - name: Install vexctl
+        env:
+          VEXCTL_VERSION: ${{ inputs.vexctl-version }}
+        run: go install "github.com/openvex/vexctl@${VEXCTL_VERSION}"
+
+      - name: Normalize OpenVEX document
+        env:
+          VEX_PATH: ${{ inputs.vex-path }}
+        run: |
+          test -f "${VEX_PATH}" || { echo "::error::OpenVEX document not found at ${VEX_PATH}"; exit 1; }
+          vexctl merge "${VEX_PATH}" > openvex.normalized.json
+          jq -e . openvex.normalized.json > /dev/null
+
+      - name: Attest OpenVEX document
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+          predicate-type: https://openvex.dev/ns/v0.2.0
+          predicate-path: openvex.normalized.json

--- a/.github/skills/gh-attested/templates/reusable-zap.yml
+++ b/.github/skills/gh-attested/templates/reusable-zap.yml
@@ -1,0 +1,61 @@
+# Reusable workflow: OWASP ZAP DAST full scan (conditional, opt-in).
+#
+# Runs the ZAP Full Scan (spider + active scan) against a running target and
+# fails the job on alerts when fail-action is true. The HTML/JSON/Markdown
+# report is attached as a build artifact by the action.
+#
+# The caller must stand up the target (a deployed preview, a service started in
+# a prior job, etc.) and pass its URL. SARIF emission is a ZAP *engine* report
+# (Automation Framework), not a native action input — emit it via cmd-options
+# and upload as a follow-on step if code-scanning ingestion is wanted (see the
+# gh-attested skill references/gate-catalog.md).
+#
+# `allow_issue_writing: false` keeps this workflow to contents: read — it does
+# not open GitHub issues.
+#
+# Usage:
+#   jobs:
+#     dast:
+#       permissions:
+#         contents: read
+#       uses: __org__/.github/.github/workflows/reusable-zap.yml@<sha>
+#       with:
+#         target: https://staging.example.com
+
+name: zap
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: 'URL of the running target to scan'
+        required: true
+        type: string
+      fail-action:
+        description: 'Fail the job when ZAP reports alerts'
+        required: false
+        type: boolean
+        default: true
+      cmd-options:
+        description: 'Additional ZAP command-line options'
+        required: false
+        type: string
+        default: '-a'
+
+permissions:
+  contents: read
+
+jobs:
+  dast:
+    name: dast
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: ZAP full scan
+        uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
+        with:
+          target: ${{ inputs.target }}
+          fail_action: ${{ inputs.fail-action }}
+          cmd_options: ${{ inputs.cmd-options }}
+          allow_issue_writing: false

--- a/.github/skills/gh-attested/templates/ruleset.json
+++ b/.github/skills/gh-attested/templates/ruleset.json
@@ -1,0 +1,39 @@
+{
+  "name": "attested-quality-gates",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "sast / analyze" },
+          { "context": "sca / dependency-review" },
+          { "context": "trivy / iac-license" },
+          { "context": "pin-check / pin-check" }
+        ]
+      }
+    },
+    { "type": "required_linear_history" },
+    { "type": "required_signatures" },
+    { "type": "non_fast_forward" },
+    { "type": "deletion" }
+  ]
+}

--- a/.github/skills/gh-attested/templates/secrets-and-vars.md
+++ b/.github/skills/gh-attested/templates/secrets-and-vars.md
@@ -1,0 +1,35 @@
+# Secrets & variables — set these yourself
+
+The skill **never reads, writes, commits, or logs a secret value.** It only
+prints the required names and the command for you to run. Run them yourself so
+the value is piped from your input, never through the agent.
+
+> ⚠️ Do not paste secret values into the chat or a workflow file. Use the
+> commands below; GitHub stores them encrypted.
+
+## Secrets — most gates need NONE
+
+Keyless Sigstore signing and every OSS scanner (CodeQL, OSV-Scanner, Trivy,
+Scorecard, vexctl, k6, ZAP) require **no secrets** — `GITHUB_TOKEN` and OIDC
+cover them. Set a secret only for the optional cases below.
+
+| Secret | When needed | Set it yourself |
+|--------|-------------|-----------------|
+| `GITLEAKS_LICENSE` | only if using org-tier gitleaks in `reusable-security.yml` | `gh secret set GITLEAKS_LICENSE` |
+| deploy credentials (e.g. `AWS_ROLE_ARN` via OIDC is preferred over a static key) | only if the deploy job needs them | `gh secret set <NAME> --env production` |
+
+Prefer OIDC (`id-token: write` + a cloud trust policy) over long-lived
+credentials wherever the target supports it.
+
+## Variables — non-secret config
+
+| Variable | Purpose | Set it yourself |
+|----------|---------|-----------------|
+| `ZAP_TARGET_URL` | DAST target (if not hard-coded) | `gh variable set ZAP_TARGET_URL` |
+| `TRIVY_SEVERITY` | override severity threshold | `gh variable set TRIVY_SEVERITY` |
+
+## Environment required-reviewers
+
+Human approval on the `production` environment is a manual step in
+**Settings → Environments → production → Required reviewers** — the skill cannot
+choose reviewers for you.

--- a/.github/workflows/reusable-attest-scan.yml
+++ b/.github/workflows/reusable-attest-scan.yml
@@ -1,0 +1,84 @@
+# Reusable workflow: the attestation "seam".
+#
+# Turns any quality-gate's evidence file (a scanner's SARIF/JSON, a load-test
+# summary, an OpenVEX document, ...) into a signed, digest-bound in-toto
+# attestation via GitHub keyless signing (`actions/attest`, custom predicate).
+# A clean result in the Security tab is *evidence*; this attestation is the
+# enforceable, verifiable *claim* — bound to a subject by digest and signed by
+# this central workflow's OIDC identity (Sigstore Public Good for public repos).
+#
+# Verification (see SECURITY.md / gh-attested skill references/verification.md):
+#   gh attestation verify <subject> --owner <owner> \
+#     --predicate-type <predicate-type> \
+#     --signer-workflow <owner>/.github/.github/workflows/reusable-attest-scan.yml
+#
+# Security note: only workflow_call inputs (controlled by the caller) and the
+# downloaded evidence artifact are used. No untrusted input reaches a shell.
+#
+# Usage:
+#   jobs:
+#     attest-sast:
+#       needs: [sast]
+#       permissions:
+#         id-token: write
+#         attestations: write
+#         contents: read
+#       uses: zircote/.github/.github/workflows/reusable-attest-scan.yml@<sha>
+#       with:
+#         subject-name: my-app
+#         subject-digest: ${{ needs.build.outputs.digest }}   # sha256:...
+#         predicate-type: https://zircote.github.io/attestations/sast/v1
+#         predicate-artifact: codeql-sarif
+#         predicate-filename: results.sarif
+
+name: attest-scan
+
+on:
+  workflow_call:
+    inputs:
+      subject-name:
+        description: 'Logical subject name (image repo, package name, or artifact label)'
+        required: true
+        type: string
+      subject-digest:
+        description: 'Subject digest the predicate is bound to (sha256:...)'
+        required: true
+        type: string
+      predicate-type:
+        description: 'URI identifying the predicate type (e.g. https://openvex.dev/ns/v0.2.0)'
+        required: true
+        type: string
+      predicate-artifact:
+        description: 'Name of the uploaded artifact containing the evidence file'
+        required: true
+        type: string
+      predicate-filename:
+        description: 'Evidence filename within the artifact (e.g. results.sarif)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  attest:
+    name: attest
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # keyless Sigstore signing
+      attestations: write    # persist the GitHub artifact attestation
+      contents: read
+    steps:
+      - name: Download evidence artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.predicate-artifact }}
+          path: predicate
+
+      - name: Attest evidence as a signed custom predicate
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+          predicate-type: ${{ inputs.predicate-type }}
+          predicate-path: predicate/${{ inputs.predicate-filename }}

--- a/.github/workflows/reusable-k6.yml
+++ b/.github/workflows/reusable-k6.yml
@@ -1,0 +1,81 @@
+# Reusable workflow: Grafana k6 load / performance gate (conditional, opt-in).
+#
+# The gate is k6's thresholds — pass/fail criteria on test metrics. On a
+# threshold breach k6 exits 99 (ThresholdsHaveFailed), failing the job. The
+# JSON summary is optionally signed as a custom performance attestation (there
+# is no standard performance predicate type).
+#
+# The caller is responsible for starting/targeting the system under test; the
+# k6 script encodes the target URL and thresholds.
+#
+# Usage:
+#   jobs:
+#     load:
+#       permissions:
+#         id-token: write
+#         attestations: write
+#         contents: read
+#       uses: zircote/.github/.github/workflows/reusable-k6.yml@<sha>
+#       with:
+#         script-path: tests/load.js
+#         attest: true
+#         subject-name: my-app
+#         subject-digest: ${{ needs.build.outputs.digest }}
+
+name: k6
+
+on:
+  workflow_call:
+    inputs:
+      script-path:
+        description: 'Path to the k6 test script'
+        required: true
+        type: string
+      attest:
+        description: 'Sign the k6 summary as a custom performance attestation'
+        required: false
+        type: boolean
+        default: false
+      subject-name:
+        description: 'Subject name for the attestation (required when attest=true)'
+        required: false
+        type: string
+        default: ''
+      subject-digest:
+        description: 'Subject digest for the attestation (required when attest=true)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  load:
+    name: load
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up k6
+        uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
+
+      - name: Run k6 load test
+        uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
+        with:
+          path: ${{ inputs.script-path }}
+          flags: --summary-export=k6-summary.json
+
+      - name: Attest performance summary
+        if: ${{ inputs.attest && inputs.subject-digest != '' }}
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+          predicate-type: https://zircote.github.io/attestations/k6-load/v1
+          predicate-path: k6-summary.json

--- a/.github/workflows/reusable-k6.yml
+++ b/.github/workflows/reusable-k6.yml
@@ -62,6 +62,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Fail fast before the load run: attest=true with no subject would
+      # otherwise silently skip the attestation and still report success.
+      - name: Validate attestation inputs
+        if: ${{ inputs.attest }}
+        env:
+          SUBJECT_NAME: ${{ inputs.subject-name }}
+          SUBJECT_DIGEST: ${{ inputs.subject-digest }}
+        run: |
+          if [ -z "${SUBJECT_NAME}" ] || [ -z "${SUBJECT_DIGEST}" ]; then
+            echo "::error::attest=true requires subject-name and subject-digest"
+            exit 1
+          fi
+
       - name: Set up k6
         uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
 
@@ -72,7 +85,7 @@ jobs:
           flags: --summary-export=k6-summary.json
 
       - name: Attest performance summary
-        if: ${{ inputs.attest && inputs.subject-digest != '' }}
+        if: ${{ inputs.attest }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ inputs.subject-name }}

--- a/.github/workflows/reusable-sast-codeql.yml
+++ b/.github/workflows/reusable-sast-codeql.yml
@@ -1,0 +1,77 @@
+# Reusable workflow: SAST via CodeQL code scanning.
+#
+# CodeQL builds a database (AST + data-flow + control-flow graphs) and runs
+# security queries, emitting SARIF 2.1.0 into the GitHub code-scanning hub. On
+# a pull request the "Code scanning results" check fails on any error/critical/
+# high finding — wire it as a required status check to make it a merge gate.
+# Free for public repositories by default (GitHub Advanced Security).
+#
+# Compiled languages (c-cpp, csharp, go, java-kotlin, swift) generally need a
+# build: pass `build-mode: autobuild` or `build-mode: manual` and call once per
+# language. Interpreted languages (javascript-typescript, python, ruby,
+# actions) work with `build-mode: none`.
+#
+# Usage:
+#   jobs:
+#     sast:
+#       permissions:
+#         security-events: write
+#         contents: read
+#         actions: read
+#       uses: zircote/.github/.github/workflows/reusable-sast-codeql.yml@<sha>
+#       with:
+#         languages: 'javascript-typescript,python'
+
+name: sast-codeql
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        description: 'Comma-separated CodeQL languages (e.g. javascript-typescript,python)'
+        required: true
+        type: string
+      build-mode:
+        description: 'CodeQL build mode: none | autobuild | manual'
+        required: false
+        type: string
+        default: 'none'
+      config-file:
+        description: 'Optional path to a codeql-config.yml'
+        required: false
+        type: string
+        default: ''
+      queries:
+        description: 'Optional query suite (e.g. security-extended)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      contents: read
+      actions: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          languages: ${{ inputs.languages }}
+          build-mode: ${{ inputs.build-mode }}
+          config-file: ${{ inputs.config-file }}
+          queries: ${{ inputs.queries }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          category: '/language:${{ inputs.languages }}'

--- a/.github/workflows/reusable-sca-osv.yml
+++ b/.github/workflows/reusable-sca-osv.yml
@@ -1,0 +1,73 @@
+# Reusable workflow: SCA via OSV-Scanner + GitHub dependency review.
+#
+# Two complementary free layers (Dependabot alerts are the third, configured at
+# the repo level and outside this workflow):
+#   - OSV-Scanner (Google, Apache-2.0): an independent second opinion against
+#     the OSV database across lockfiles and ecosystems; uploads SARIF to the
+#     code-scanning hub.
+#   - dependency-review-action: the PR merge gate — fails the check when a PR
+#     introduces a vulnerable dependency or a disallowed license. Public-repo
+#     free.
+#
+# Usage:
+#   jobs:
+#     sca:
+#       permissions:
+#         actions: read
+#         contents: read
+#         security-events: write
+#         pull-requests: write
+#       uses: zircote/.github/.github/workflows/reusable-sca-osv.yml@<sha>
+#       with:
+#         fail-on-severity: high
+
+name: sca-osv
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: 'dependency-review threshold: low | moderate | high | critical'
+        required: false
+        type: string
+        default: 'high'
+      scan-args:
+        description: 'OSV-Scanner arguments'
+        required: false
+        type: string
+        default: |-
+          --recursive
+          ./
+
+permissions:
+  contents: read
+
+jobs:
+  # OSV-Scanner ships an official reusable workflow that scans, generates SARIF,
+  # and uploads it to code scanning. Pinned to the repo's release SHA.
+  osv-scan:
+    name: osv-scanner
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: ${{ inputs.scan-args }}
+
+  dependency-review:
+    name: dependency-review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -1,0 +1,62 @@
+# Reusable workflow: OpenSSF Scorecard — supply-chain posture.
+#
+# Scores 0-10 heuristics (Branch-Protection, Code-Review, Token-Permissions,
+# Dangerous-Workflow, Pinned-Dependencies, Signed-Releases, ...) and uploads
+# SARIF to the code-scanning hub. With publish-results: true the run is
+# published to the OpenSSF REST API (a public posture attestation + badge),
+# which requires id-token: write.
+#
+# Recommended trigger in the caller: branch_protection_rule, schedule (weekly),
+# and push to the default branch.
+#
+# Usage:
+#   jobs:
+#     scorecard:
+#       permissions:
+#         security-events: write
+#         id-token: write
+#         contents: read
+#         actions: read
+#       uses: zircote/.github/.github/workflows/reusable-scorecard.yml@<sha>
+
+name: scorecard
+
+on:
+  workflow_call:
+    inputs:
+      publish-results:
+        description: 'Publish results to the OpenSSF API (public repos only)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF
+      id-token: write          # publish to OpenSSF API
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: ${{ inputs.publish-results }}
+
+      - name: Upload Scorecard SARIF
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: scorecard.sarif
+          category: scorecard

--- a/.github/workflows/reusable-trivy.yml
+++ b/.github/workflows/reusable-trivy.yml
@@ -1,0 +1,107 @@
+# Reusable workflow: Trivy — container image, IaC misconfiguration, and license.
+#
+# Complements sbom-and-scan.yml (SBOM + Grype). Trivy adds:
+#   - image vulnerability scan (when image-ref is set), fail-closed on severity;
+#   - IaC misconfiguration scan of the repo (Docker/K8s/Terraform/CloudFormation);
+#   - license scan (Forbidden->CRITICAL, Restricted->HIGH).
+# All findings normalize on SARIF and land in the code-scanning hub, so the
+# code-scanning required check is the merge gate for the repo scan; the image
+# scan additionally fails the job on findings at/above `severity`.
+#
+# SECURITY: aquasecurity/trivy-action is pinned to a full commit SHA. In
+# March 2026 (CVE-2026-33634) an attacker force-pushed 76 of 77 trivy-action
+# tags to credential-stealing malware; tag references are unsafe. Never replace
+# this SHA with a tag.
+#
+# Usage:
+#   jobs:
+#     trivy:
+#       permissions:
+#         contents: read
+#         security-events: write
+#         actions: read
+#       uses: zircote/.github/.github/workflows/reusable-trivy.yml@<sha>
+#       with:
+#         image-ref: ghcr.io/zircote/app@sha256:...   # omit to scan repo only
+
+name: trivy
+
+on:
+  workflow_call:
+    inputs:
+      image-ref:
+        description: 'Image to scan by digest (empty = skip image scan)'
+        required: false
+        type: string
+        default: ''
+      severity:
+        description: 'Severities to report/fail on'
+        required: false
+        type: string
+        default: 'HIGH,CRITICAL'
+      scan-iac:
+        description: 'Scan repo for IaC misconfiguration + license issues'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  iac-license:
+    name: iac-license
+    if: ${{ inputs.scan-iac }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Trivy IaC + license scan (filesystem)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: misconfig,license
+          format: sarif
+          output: trivy-iac-license.sarif
+          severity: ${{ inputs.severity }}
+          exit-code: '0'   # report to code scanning; the code-scanning check is the gate
+
+      - name: Upload IaC + license SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: trivy-iac-license.sarif
+          category: trivy-iac-license
+
+  image:
+    name: image
+    if: ${{ inputs.image-ref != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
+    steps:
+      - name: Trivy image vulnerability scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ inputs.image-ref }}
+          format: sarif
+          output: trivy-image.sarif
+          severity: ${{ inputs.severity }}
+          exit-code: '1'   # fail-closed on image vulnerabilities
+
+      - name: Upload image SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/.github/workflows/reusable-verify-gates.yml
+++ b/.github/workflows/reusable-verify-gates.yml
@@ -1,0 +1,89 @@
+# Reusable workflow: fail-closed verification of gate attestations.
+#
+# Runs `gh attestation verify` against a subject for each required predicate
+# type. Any verification failure exits non-zero, so placing this job in a
+# deploy job's `needs:` halts an unverified or improperly-signed artifact
+# before it ships. Under SLSA L3 the signer identity is the central signing
+# workflow (the Fulcio SAN), so --signer-workflow is mandatory; --owner alone
+# is insufficient.
+#
+# Usage:
+#   jobs:
+#     verify:
+#       permissions:
+#         id-token: write
+#         contents: read
+#         attestations: read
+#         packages: read
+#       uses: zircote/.github/.github/workflows/reusable-verify-gates.yml@<sha>
+#       with:
+#         subject-ref: oci://ghcr.io/zircote/app@sha256:...
+#         owner: zircote
+#         signer-workflow: zircote/.github/.github/workflows/reusable-attest-scan.yml
+#         predicate-types: |-
+#           https://zircote.github.io/attestations/sast/v1
+#           https://openvex.dev/ns/v0.2.0
+#     deploy:
+#       needs: [verify]
+#       ...
+
+name: verify-gates
+
+on:
+  workflow_call:
+    inputs:
+      subject-ref:
+        description: 'Subject to verify (oci://...@sha256 or a file path)'
+        required: true
+        type: string
+      owner:
+        description: 'Repository owner that produced the attestations'
+        required: true
+        type: string
+      signer-workflow:
+        description: 'Signing workflow identity (owner/.github/.github/workflows/reusable-attest-scan.yml)'
+        required: true
+        type: string
+      predicate-types:
+        description: 'Newline- or whitespace-separated predicate type URIs to require'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: read
+      packages: read
+    steps:
+      - name: Verify gate attestations (fail-closed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SUBJECT: ${{ inputs.subject-ref }}
+          OWNER: ${{ inputs.owner }}
+          SIGNER: ${{ inputs.signer-workflow }}
+          PREDICATE_TYPES: ${{ inputs.predicate-types }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PREDICATE_TYPES//[[:space:]]/}" ]; then
+            echo "Verifying ${SUBJECT} (default provenance predicate)"
+            gh attestation verify "${SUBJECT}" --owner "${OWNER}" --signer-workflow "${SIGNER}"
+          else
+            failed=0
+            for pt in ${PREDICATE_TYPES}; do
+              echo "Verifying ${SUBJECT} against predicate ${pt}"
+              if ! gh attestation verify "${SUBJECT}" --owner "${OWNER}" \
+                    --signer-workflow "${SIGNER}" --predicate-type "${pt}"; then
+                echo "::error::verification failed for predicate ${pt}"
+                failed=1
+              fi
+            done
+            exit "${failed}"
+          fi

--- a/.github/workflows/reusable-verify-gates.yml
+++ b/.github/workflows/reusable-verify-gates.yml
@@ -3,13 +3,20 @@
 # Runs `gh attestation verify` against a subject for each required predicate
 # type. Any verification failure exits non-zero, so placing this job in a
 # deploy job's `needs:` halts an unverified or improperly-signed artifact
-# before it ships. Under SLSA L3 the signer identity is the central signing
-# workflow (the Fulcio SAN), so --signer-workflow is mandatory; --owner alone
-# is insufficient.
+# before it ships. Under SLSA L3 the signer identity is the workflow that ran
+# `actions/attest` (the Fulcio SAN), so --signer-workflow is mandatory; --owner
+# alone is insufficient.
+#
+# IMPORTANT: this workflow verifies ONE signer per invocation. Different
+# predicates are signed by different workflows — the seam
+# (reusable-attest-scan.yml) signs the SARIF gates, while OpenVEX self-signs in
+# reusable-vex.yml and k6 in reusable-k6.yml. Call this workflow once per signer
+# group; mixing predicates from different signers fails closed on a VALID
+# artifact. See docs/reference/attestation-predicates/ ("Signed by").
 #
 # Usage:
 #   jobs:
-#     verify:
+#     verify-seam:
 #       permissions:
 #         contents: read
 #         attestations: read
@@ -21,9 +28,20 @@
 #         signer-workflow: zircote/.github/.github/workflows/reusable-attest-scan.yml
 #         predicate-types: |-
 #           https://zircote.github.io/attestations/sast/v1
-#           https://openvex.dev/ns/v0.2.0
+#           https://zircote.github.io/attestations/sca/v1
+#     verify-vex:                          # OpenVEX is signed by reusable-vex.yml
+#       permissions:
+#         contents: read
+#         attestations: read
+#         packages: read
+#       uses: zircote/.github/.github/workflows/reusable-verify-gates.yml@<sha>
+#       with:
+#         subject-ref: oci://ghcr.io/zircote/app@sha256:...
+#         owner: zircote
+#         signer-workflow: zircote/.github/.github/workflows/reusable-vex.yml
+#         predicate-types: https://openvex.dev/ns/v0.2.0
 #     deploy:
-#       needs: [verify]
+#       needs: [verify-seam, verify-vex]
 #       ...
 
 name: verify-gates
@@ -40,7 +58,7 @@ on:
         required: true
         type: string
       signer-workflow:
-        description: 'Signing workflow identity (owner/.github/.github/workflows/reusable-attest-scan.yml)'
+        description: 'The single signer for ALL predicate-types in this call (e.g. reusable-attest-scan.yml for seam-signed gates, reusable-vex.yml for OpenVEX). One signer per invocation.'
         required: true
         type: string
       predicate-types:

--- a/.github/workflows/reusable-verify-gates.yml
+++ b/.github/workflows/reusable-verify-gates.yml
@@ -11,7 +11,6 @@
 #   jobs:
 #     verify:
 #       permissions:
-#         id-token: write
 #         contents: read
 #         attestations: read
 #         packages: read
@@ -45,10 +44,9 @@ on:
         required: true
         type: string
       predicate-types:
-        description: 'Newline- or whitespace-separated predicate type URIs to require'
-        required: false
+        description: 'Newline- or whitespace-separated predicate type URIs to require (at least one)'
+        required: true
         type: string
-        default: ''
 
 permissions:
   contents: read
@@ -58,7 +56,6 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       attestations: read
       packages: read
@@ -72,18 +69,19 @@ jobs:
           PREDICATE_TYPES: ${{ inputs.predicate-types }}
         run: |
           set -euo pipefail
+          # Fail closed: refuse to "verify" with no required predicate. An empty
+          # list would otherwise let a deploy proceed against no specific gate.
           if [ -z "${PREDICATE_TYPES//[[:space:]]/}" ]; then
-            echo "Verifying ${SUBJECT} (default provenance predicate)"
-            gh attestation verify "${SUBJECT}" --owner "${OWNER}" --signer-workflow "${SIGNER}"
-          else
-            failed=0
-            for pt in ${PREDICATE_TYPES}; do
-              echo "Verifying ${SUBJECT} against predicate ${pt}"
-              if ! gh attestation verify "${SUBJECT}" --owner "${OWNER}" \
-                    --signer-workflow "${SIGNER}" --predicate-type "${pt}"; then
-                echo "::error::verification failed for predicate ${pt}"
-                failed=1
-              fi
-            done
-            exit "${failed}"
+            echo "::error::predicate-types is required and must name at least one predicate URI (fail closed)"
+            exit 1
           fi
+          failed=0
+          for pt in ${PREDICATE_TYPES}; do
+            echo "Verifying ${SUBJECT} against predicate ${pt}"
+            if ! gh attestation verify "${SUBJECT}" --owner "${OWNER}" \
+                  --signer-workflow "${SIGNER}" --predicate-type "${pt}"; then
+              echo "::error::verification failed for predicate ${pt}"
+              failed=1
+            fi
+          done
+          exit "${failed}"

--- a/.github/workflows/reusable-vex.yml
+++ b/.github/workflows/reusable-vex.yml
@@ -1,0 +1,90 @@
+# Reusable workflow: OpenVEX vulnerability disposition.
+#
+# A clean scan is rarely zero findings. An OpenVEX document (maintained in the
+# repo) records per-vulnerability status (not_affected / affected / fixed /
+# under_investigation) so the deploy gate can enforce "no UNDISPOSITIONED
+# high/critical vulnerabilities" rather than "zero findings". This workflow
+# normalizes the document with `vexctl merge` and signs it as an OpenVEX
+# attestation bound to the artifact digest.
+#
+# vexctl is installed via `go install` pinned to a module version (immutable via
+# the Go checksum database) — there is no official vexctl GitHub Action.
+#
+# Usage:
+#   jobs:
+#     vex:
+#       needs: [build]
+#       permissions:
+#         id-token: write
+#         attestations: write
+#         contents: read
+#       uses: zircote/.github/.github/workflows/reusable-vex.yml@<sha>
+#       with:
+#         subject-name: ghcr.io/zircote/app
+#         subject-digest: ${{ needs.build.outputs.digest }}
+#         vex-path: .vex/openvex.json
+
+name: vex
+
+on:
+  workflow_call:
+    inputs:
+      subject-name:
+        description: 'Subject the OpenVEX statement is bound to'
+        required: true
+        type: string
+      subject-digest:
+        description: 'Subject digest (sha256:...)'
+        required: true
+        type: string
+      vex-path:
+        description: 'Path to the OpenVEX document in the repository'
+        required: false
+        type: string
+        default: '.vex/openvex.json'
+      vexctl-version:
+        description: 'vexctl module version to install'
+        required: false
+        type: string
+        default: 'v0.4.1'
+
+permissions:
+  contents: read
+
+jobs:
+  attest-vex:
+    name: attest-vex
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+
+      - name: Install vexctl
+        env:
+          VEXCTL_VERSION: ${{ inputs.vexctl-version }}
+        run: go install "github.com/openvex/vexctl@${VEXCTL_VERSION}"
+
+      - name: Normalize OpenVEX document
+        env:
+          VEX_PATH: ${{ inputs.vex-path }}
+        run: |
+          test -f "${VEX_PATH}" || { echo "::error::OpenVEX document not found at ${VEX_PATH}"; exit 1; }
+          vexctl merge "${VEX_PATH}" > openvex.normalized.json
+          jq -e . openvex.normalized.json > /dev/null
+
+      - name: Attest OpenVEX document
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+          predicate-type: https://openvex.dev/ns/v0.2.0
+          predicate-path: openvex.normalized.json

--- a/.github/workflows/reusable-zap.yml
+++ b/.github/workflows/reusable-zap.yml
@@ -1,0 +1,61 @@
+# Reusable workflow: OWASP ZAP DAST full scan (conditional, opt-in).
+#
+# Runs the ZAP Full Scan (spider + active scan) against a running target and
+# fails the job on alerts when fail-action is true. The HTML/JSON/Markdown
+# report is attached as a build artifact by the action.
+#
+# The caller must stand up the target (a deployed preview, a service started in
+# a prior job, etc.) and pass its URL. SARIF emission is a ZAP *engine* report
+# (Automation Framework), not a native action input — emit it via cmd-options
+# and upload as a follow-on step if code-scanning ingestion is wanted (see the
+# gh-attested skill references/gate-catalog.md).
+#
+# `allow_issue_writing: false` keeps this workflow to contents: read — it does
+# not open GitHub issues.
+#
+# Usage:
+#   jobs:
+#     dast:
+#       permissions:
+#         contents: read
+#       uses: zircote/.github/.github/workflows/reusable-zap.yml@<sha>
+#       with:
+#         target: https://staging.example.com
+
+name: zap
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: 'URL of the running target to scan'
+        required: true
+        type: string
+      fail-action:
+        description: 'Fail the job when ZAP reports alerts'
+        required: false
+        type: boolean
+        default: true
+      cmd-options:
+        description: 'Additional ZAP command-line options'
+        required: false
+        type: string
+        default: '-a'
+
+permissions:
+  contents: read
+
+jobs:
+  dast:
+    name: dast
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: ZAP full scan
+        uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
+        with:
+          target: ${{ inputs.target }}
+          fail_action: ${{ inputs.fail-action }}
+          cmd_options: ${{ inputs.cmd-options }}
+          allow_issue_writing: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,52 @@ Caller rules:
   `--signer-workflow zircote/.github/.github/workflows/sign-and-attest.yml`
   (`--repo` alone fails under SLSA L3 — the SAN is the central signer).
 
+## Attested Quality Gates (CI gate suite)
+
+Centralized reusable workflows that bring a **public** OSS repo to complete
+quality-gate coverage with GitHub-native + free-for-OSS tooling, turning each
+gate's verdict into a signed, digest-bound attestation. Constituted and applied
+by the **`gh-attested`** skill (assess → plan → implement). Composes with —
+does not duplicate — `attested-delivery` (build provenance, SBOM signing,
+fail-closed verify), `reusable-security.yml` (gitleaks + language audits), and
+`sbom-and-scan.yml` (CycloneDX/SPDX + Grype).
+
+| Workflow | Gate | Key inputs |
+|----------|------|------------|
+| `reusable-attest-scan.yml` | **The seam** — signs any evidence file as a custom-predicate attestation bound to a digest | `subject-name`, `subject-digest`, `predicate-type`, `predicate-artifact`, `predicate-filename` |
+| `reusable-sast-codeql.yml` | SAST (CodeQL → code scanning) | `languages`, `build-mode` |
+| `reusable-sca-osv.yml` | SCA (OSV-Scanner + dependency review PR gate) | `fail-on-severity`, `scan-args` |
+| `reusable-trivy.yml` | Container vuln + IaC misconfig + license | `image-ref`, `severity`, `scan-iac` |
+| `reusable-scorecard.yml` | Supply-chain posture (OpenSSF Scorecard) | `publish-results` |
+| `reusable-vex.yml` | Vulnerability disposition (OpenVEX via `vexctl`) | `subject-name`, `subject-digest`, `vex-path` |
+| `reusable-k6.yml` | Load / performance (opt-in; needs a target) | `script-path`, `attest` |
+| `reusable-zap.yml` | DAST (OWASP ZAP; opt-in; needs a target) | `target`, `fail-action` |
+| `reusable-verify-gates.yml` | Fail-closed `gh attestation verify` before deploy | `subject-ref`, `owner`, `signer-workflow`, `predicate-types` |
+
+Caller rules (same SHA-pinning + fail-closed discipline as above):
+
+- Pin every `uses:` to this repo's full 40-char commit SHA; **pin third-party
+  actions by SHA, never tag** (Trivy CVE-2026-33634 — tags force-pushed to
+  malware). `aquasecurity/trivy-action` is pinned to a maintainer-signed
+  post-incident commit.
+- SARIF-emitting gates land in the code-scanning hub; make them merge gates via
+  required status checks (`templates/ruleset.json`). Context names are
+  `<caller job id> / <called job name>` (e.g. `sast / analyze`).
+- Deploy jobs `needs:` the verify job. Verification: `gh attestation verify`
+  with `--owner` **and** `--signer-workflow
+  zircote/.github/.github/workflows/reusable-attest-scan.yml`. Commands live in
+  `SECURITY.md` ("Verifying Quality-Gate Attestations").
+- Repo configuration (rulesets, settings, native scanners, environments) is
+  applied idempotently with a diff-preview + confirm; **secrets/variables are
+  guided, never written or logged** — see the skill's `references/repo-config.md`.
+
+The skill is self-contained at `.github/skills/gh-attested/` (SKILL.md +
+`references/` + `__org__`-parameterized `templates/`). Honest boundaries:
+private repos need GHAS licenses for CodeQL/secret-scanning/dependency-review;
+GitHub has no k8s admission control (external — Kyverno/policy-controller);
+there is no standard performance predicate; a signed attestation proves a gate
+*ran and recorded a verdict*, not that it *passed*.
+
 ## Available Composite Actions
 
 | Action | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,9 +185,11 @@ Caller rules (same SHA-pinning + fail-closed discipline as above):
 - SARIF-emitting gates land in the code-scanning hub; make them merge gates via
   required status checks (`templates/ruleset.json`). Context names are
   `<caller job id> / <called job name>` (e.g. `sast / analyze`).
-- Deploy jobs `needs:` the verify job. Verification: `gh attestation verify`
-  with `--owner` **and** `--signer-workflow
-  zircote/.github/.github/workflows/reusable-attest-scan.yml`. Commands live in
+- Deploy jobs `needs:` the verify job(s). Verification: `gh attestation verify`
+  with `--owner` **and** `--signer-workflow` pinned to the workflow that signed
+  that predicate — the seam (`reusable-attest-scan.yml`) for the SARIF gates,
+  `reusable-vex.yml` for OpenVEX, `reusable-k6.yml` for k6. `reusable-verify-gates.yml`
+  takes one signer per call, so call it once per signer group. Commands live in
   `SECURITY.md` ("Verifying Quality-Gate Attestations").
 - Repo configuration (rulesets, settings, native scanners, environments) is
   applied idempotently with a diff-preview + confirm; **secrets/variables are

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,21 +80,22 @@ gh attestation verify <binary> --repo zircote/<repo>
 Repositories wired to the attested **quality gates** (the `gh-attested` skill)
 additionally record a signed, digest-bound attestation for each CI gate — SAST,
 SCA, container/IaC/license scan, supply-chain posture, and vulnerability
-disposition. Signing runs in the central seam workflow
-(`zircote/.github/.github/workflows/reusable-attest-scan.yml`), so the signer
-identity (SLSA L3) is that workflow, not the source repo — `--signer-workflow`
-is required.
+disposition. Each predicate is pinned to **the workflow that actually signed
+it** (SLSA L3 cert identity): the seam (`reusable-attest-scan.yml`) signs the
+SARIF gates, while OpenVEX self-signs in `reusable-vex.yml` — so
+`--signer-workflow` differs per predicate.
 
 ```sh
 SUBJECT=oci://ghcr.io/zircote/<repo>@${DIGEST}   # or a release-artifact ref
-SIGNER=zircote/.github/.github/workflows/reusable-attest-scan.yml
+SEAM=zircote/.github/.github/workflows/reusable-attest-scan.yml
 
-# SAST gate (other gates: swap the predicate-type)
-gh attestation verify "$SUBJECT" --owner zircote --signer-workflow "$SIGNER" \
+# Seam-signed gate (SAST shown; other SARIF gates: swap the predicate-type)
+gh attestation verify "$SUBJECT" --owner zircote --signer-workflow "$SEAM" \
   --predicate-type https://zircote.github.io/attestations/sast/v1
 
-# Vulnerability disposition (OpenVEX — standard predicate type)
-gh attestation verify "$SUBJECT" --owner zircote --signer-workflow "$SIGNER" \
+# Vulnerability disposition (OpenVEX — self-signed by reusable-vex.yml)
+gh attestation verify "$SUBJECT" --owner zircote \
+  --signer-workflow zircote/.github/.github/workflows/reusable-vex.yml \
   --predicate-type https://openvex.dev/ns/v0.2.0
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,3 +74,31 @@ cosign verify-attestation "ghcr.io/zircote/<repo>@${DIGEST}" \
 gh release download <tag> --repo zircote/<repo>
 gh attestation verify <binary> --repo zircote/<repo>
 ```
+
+## Verifying Quality-Gate Attestations
+
+Repositories wired to the attested **quality gates** (the `gh-attested` skill)
+additionally record a signed, digest-bound attestation for each CI gate — SAST,
+SCA, container/IaC/license scan, supply-chain posture, and vulnerability
+disposition. Signing runs in the central seam workflow
+(`zircote/.github/.github/workflows/reusable-attest-scan.yml`), so the signer
+identity (SLSA L3) is that workflow, not the source repo — `--signer-workflow`
+is required.
+
+```sh
+SUBJECT=oci://ghcr.io/zircote/<repo>@${DIGEST}   # or a release-artifact ref
+SIGNER=zircote/.github/.github/workflows/reusable-attest-scan.yml
+
+# SAST gate (other gates: swap the predicate-type)
+gh attestation verify "$SUBJECT" --owner zircote --signer-workflow "$SIGNER" \
+  --predicate-type https://zircote.github.io/attestations/sast/v1
+
+# Vulnerability disposition (OpenVEX — standard predicate type)
+gh attestation verify "$SUBJECT" --owner zircote --signer-workflow "$SIGNER" \
+  --predicate-type https://openvex.dev/ns/v0.2.0
+```
+
+A successful verification proves the attestation is authentic and bound to the
+artifact — inspect the predicate body (`--format json | jq …`) to read the
+gate's recorded verdict. The full per-predicate command set is in the
+`gh-attested` skill's `references/verification.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ documentation for four kinds of need:
 ## How-to guides
 
 - [Onboard a repo to attested delivery](how-to/onboard-a-repo-to-attested-delivery.md)
+- [Onboard a repo to attested quality gates](how-to/onboard-a-repo-to-attested-quality-gates.md)
 - [Enforce action SHA pinning](how-to/enforce-action-sha-pinning.md)
 - [Generate an SBOM and vulnerability scan](how-to/generate-sbom-and-vuln-scan.md)
 - [Emit DORA deployment metrics](how-to/emit-dora-deployment-metrics.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,9 @@ executable, fully self-contained onboarding protocol for any org or repo.
 
 - [Reusable workflows](reference/workflows.md) — every centralized
   attested-delivery workflow: inputs, outputs, secrets, permissions.
+- [Attestation predicate definitions](reference/attestation-predicates/README.md)
+  — the custom predicate types the quality gates sign: URI, body format, verdict
+  rule, JSON Schema.
 - Language CI, release, security, and docs workflows are summarized in
   [CLAUDE.md](../CLAUDE.md) and the [repo README](../README.md#reusable-workflows).
 

--- a/docs/how-to/onboard-a-repo-to-attested-quality-gates.md
+++ b/docs/how-to/onboard-a-repo-to-attested-quality-gates.md
@@ -1,0 +1,91 @@
+---
+diataxis_type: how-to
+diataxis_goal: bring a public OSS repo to complete, attested quality-gate coverage
+---
+
+# How to Onboard a Repo to Attested Quality Gates
+
+## Overview
+
+This guide wires a **public** open-source repository to the centralized quality
+gates — SAST, SCA, secret detection, container/IaC/license scanning, SBOM,
+vulnerability disposition, supply-chain posture, peer review, and (optionally)
+load and DAST — and turns each gate's verdict into a signed, digest-bound
+attestation. It composes with
+[attested delivery](./onboard-a-repo-to-attested-delivery.md): build provenance
+and SBOM signing come from there; this guide adds the scanning/testing gates and
+the attestation seam.
+
+The `gh-attested` skill automates this end to end (assess → plan → implement).
+This guide is the manual path and the mental model.
+
+## Prerequisites
+
+- A **public** repository (the GitHub-proprietary scanners — CodeQL, secret
+  scanning, dependency review — are free only on public repos).
+- `gh` CLI authenticated; permission to edit workflows and repo settings.
+- The central reusable workflows live on `zircote/.github`; record its HEAD SHA
+  — it is the pin for every caller.
+
+## 1. Assess current coverage
+
+Run the queries in the skill's `references/assessment.md` and fill the coverage
+matrix: for each of the 12 gates — present? attested? a merge gate? a deploy
+gate? Note the repo's languages (drives CodeQL `languages`) and whether a
+container image or running app exists (drives Trivy image scan, k6, ZAP).
+
+## 2. Wire the merge-time gates
+
+Copy `templates/quality-gates-caller.yml` to `.github/workflows/quality-gates.yml`,
+replace `__org__` with `zircote`, pin every `@<sha>`, and set `languages:` and
+gate inputs for the repo. The universal core:
+
+```yaml
+jobs:
+  sast:    # CodeQL → code scanning
+  sca:     # OSV-Scanner + dependency-review PR gate
+  posture: # OpenSSF Scorecard
+  trivy:   # IaC + license (+ image when image-ref is set)
+  pin-check:
+```
+
+Add `dependabot.yml` (github-actions ecosystem) and a `CODEOWNERS` from the
+templates.
+
+## 3. Add the attestation seam (deploy-time gates)
+
+For each gate whose verdict must gate *deployment* (not just merge), have the
+gate job upload its evidence file as an artifact, then call
+`reusable-attest-scan.yml` with that gate's predicate type (see
+`references/attestation-seam.md`). Defer build-provenance and SBOM signing to
+`sign-and-attest.yml` (attested delivery).
+
+## 4. Enforce
+
+- **Merge**: apply `templates/ruleset.json` (`gh api -X POST
+  repos/<o>/<r>/rulesets --input ruleset.json`) after a diff-against-current
+  preview — required status checks (`sast / analyze`, `sca / dependency-review`,
+  `trivy / iac-license`, `pin-check / pin-check`), required reviews + CODEOWNERS,
+  signed commits, linear history.
+- **Native scanners**: enable code-scanning default setup, secret scanning, and
+  push protection via the API (see `references/repo-config.md`).
+- **Deploy**: put `reusable-verify-gates.yml` in the deploy job's `needs:` —
+  fail-closed `gh attestation verify` before anything ships.
+
+Secrets and variables are **guided, never written**: most gates need none. Set
+any optional ones (`GITLEAKS_LICENSE`, deploy credentials) yourself with
+`gh secret set`.
+
+## 5. Verify end-to-end
+
+Run `actionlint` and `pin-check` (zero unpinned `uses:`), dispatch the caller,
+confirm SARIF lands in the Security tab and the seam produces a signed
+attestation, then run every command in `references/verification.md`
+**independently** from a workstation against the produced attestation.
+
+## Boundaries
+
+GitHub gates merges and deployment jobs, not Kubernetes admission (external —
+Kyverno / policy-controller). Private repos need GHAS licenses for
+CodeQL/secret-scanning/dependency-review. A signed attestation proves a gate ran
+and recorded a verdict, not that it passed — read the verdict.

--- a/docs/reference/attestation-predicates/README.md
+++ b/docs/reference/attestation-predicates/README.md
@@ -1,0 +1,65 @@
+---
+diataxis_type: reference
+diataxis_goal: define the custom attestation predicate types the quality gates sign
+---
+
+# Attestation Predicate Definitions
+
+The `gh-attested` quality gates turn each gate's verdict into a signed,
+digest-bound in-toto attestation (see the
+[`gh-attested` skill](../../../.github/skills/gh-attested/SKILL.md) and its
+`references/attestation-seam.md`). Most gates use a **custom predicate type**
+because no standard one exists. This directory is the canonical definition of
+each custom type: its identifier (URI), the predicate **body** that
+`reusable-attest-scan.yml` (or `reusable-k6.yml`) signs, the **verdict rule** a
+verifier applies, and a JSON Schema for the body.
+
+> **Namespace note.** The `https://zircote.github.io/attestations/<gate>/v1`
+> URIs are **stable type identifiers**, used with `gh attestation verify
+> --predicate-type`. They need not be live URLs to function. These definitions
+> are the source of truth; if/when `zircote.github.io` serves them, this tree is
+> what gets published.
+
+## Custom predicate types
+
+| Predicate type (URI) | Signed by | Body format | Verdict rule | Schema |
+|----------------------|-----------|-------------|--------------|--------|
+| `…/attestations/sast/v1` | `reusable-attest-scan.yml` | CodeQL SARIF 2.1.0 | fail on any `error`/high+ result | [sast/v1](sast/v1/schema.json) |
+| `…/attestations/sca/v1` | `reusable-attest-scan.yml` | OSV-Scanner SARIF 2.1.0 | fail on vuln ≥ threshold | [sca/v1](sca/v1/schema.json) |
+| `…/attestations/container-scan/v1` | `reusable-attest-scan.yml` | Trivy image SARIF 2.1.0 | fail on vuln ≥ severity | [container-scan/v1](container-scan/v1/schema.json) |
+| `…/attestations/iac-license/v1` | `reusable-attest-scan.yml` | Trivy fs SARIF 2.1.0 | fail on misconfig/license ≥ severity | [iac-license/v1](iac-license/v1/schema.json) |
+| `…/attestations/scorecard/v1` | `reusable-attest-scan.yml` | OpenSSF Scorecard SARIF 2.1.0 | advisory; enforce min score | [scorecard/v1](scorecard/v1/schema.json) |
+| `…/attestations/dast/v1` | `reusable-attest-scan.yml` | OWASP ZAP SARIF 2.1.0 (AF) | fail on alert ≥ risk | [dast/v1](dast/v1/schema.json) |
+| `…/attestations/k6-load/v1` | `reusable-k6.yml` | k6 `--summary-export` JSON | fail if any threshold failed | [k6-load/v1](k6-load/v1/schema.json) |
+
+## Standard predicate types (not defined here)
+
+These gates use predicate types defined upstream — do **not** redefine them:
+
+- **Vulnerability disposition** — `https://openvex.dev/ns/v0.2.0` (OpenVEX),
+  signed by `reusable-vex.yml`.
+- **Build provenance** — `https://slsa.dev/provenance/v1` (SLSA), signed by
+  `attested-delivery`'s `sign-and-attest.yml`.
+- **SBOM** — SPDX / CycloneDX via `actions/attest-sbom` (attested-delivery /
+  `sbom-and-scan.yml`).
+
+## Reading the verdict
+
+Every custom type's body is the tool's native evidence document. A valid
+`gh attestation verify` proves the attestation is authentic and bound to the
+subject — **not** that the gate passed. Apply the verdict rule against the body:
+
+```bash
+gh attestation verify "$SUBJECT" --owner zircote \
+  --signer-workflow zircote/.github/.github/workflows/reusable-attest-scan.yml \
+  --predicate-type https://zircote.github.io/attestations/sast/v1 \
+  --format json \
+  | jq '[.[0].verificationResult.statement.predicate.runs[].results[]?
+         | select(.level=="error")] | length'   # 0 ⇒ pass
+```
+
+## Versioning
+
+A predicate type's URI ends in a major version (`/v1`). A breaking change to the
+body contract or verdict rule bumps to `/v2` (a new directory); `/v1` stays
+immutable so existing attestations keep verifying.

--- a/docs/reference/attestation-predicates/container-scan/v1/schema.json
+++ b/docs/reference/attestation-predicates/container-scan/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/container-scan/v1",
+  "title": "zircote container-vulnerability gate predicate (Trivy image, SARIF 2.1.0)",
+  "description": "Predicate body is the unmodified SARIF 2.1.0 log produced by a Trivy image scan and signed by reusable-attest-scan.yml. Verdict rule: the gate FAILS if any result reports a vulnerability at or above the configured severity (default HIGH,CRITICAL); otherwise it PASSES. Verifiers MUST read runs[].results.",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "version": { "const": "2.1.0" },
+    "$schema": { "type": "string" },
+    "runs": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/docs/reference/attestation-predicates/dast/v1/schema.json
+++ b/docs/reference/attestation-predicates/dast/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/dast/v1",
+  "title": "zircote DAST gate predicate (OWASP ZAP, SARIF 2.1.0)",
+  "description": "Predicate body is the SARIF 2.1.0 log emitted by the OWASP ZAP Automation Framework full scan, signed by reusable-attest-scan.yml. (ZAP emits SARIF as an engine report, not a native action input — see reusable-zap.yml.) Verdict rule: the gate FAILS on any reported alert at or above the configured risk; otherwise it PASSES. Verifiers MUST read runs[].results.",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "version": { "const": "2.1.0" },
+    "$schema": { "type": "string" },
+    "runs": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/docs/reference/attestation-predicates/iac-license/v1/schema.json
+++ b/docs/reference/attestation-predicates/iac-license/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/iac-license/v1",
+  "title": "zircote IaC + license gate predicate (Trivy filesystem, SARIF 2.1.0)",
+  "description": "Predicate body is the unmodified SARIF 2.1.0 log produced by a Trivy filesystem scan with the misconfig and license scanners, signed by reusable-attest-scan.yml. Verdict rule: the gate FAILS on any misconfiguration or license finding at or above the configured severity (Forbidden->CRITICAL, Restricted->HIGH); otherwise it PASSES. Verifiers MUST read runs[].results.",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "version": { "const": "2.1.0" },
+    "$schema": { "type": "string" },
+    "runs": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/docs/reference/attestation-predicates/k6-load/v1/schema.json
+++ b/docs/reference/attestation-predicates/k6-load/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/k6-load/v1",
+  "title": "zircote load/performance gate predicate (Grafana k6 summary export)",
+  "description": "Predicate body is the JSON document produced by k6 --summary-export, signed by reusable-k6.yml. There is no standard performance predicate type; this is a custom type. Verdict rule: the gate FAILS if any threshold failed (k6 exits 99, ThresholdsHaveFailed); otherwise it PASSES. Verifiers read metrics[*].thresholds[*].ok — a false entry is a fail.",
+  "type": "object",
+  "required": ["metrics"],
+  "properties": {
+    "metrics": {
+      "type": "object",
+      "description": "Per-metric values; each metric may carry a thresholds object whose entries report ok=true|false.",
+      "additionalProperties": { "type": "object" }
+    },
+    "root_group": { "type": "object" }
+  }
+}

--- a/docs/reference/attestation-predicates/sast/v1/schema.json
+++ b/docs/reference/attestation-predicates/sast/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/sast/v1",
+  "title": "zircote SAST gate predicate (CodeQL, SARIF 2.1.0)",
+  "description": "Predicate body is the unmodified SARIF 2.1.0 log produced by CodeQL code scanning and signed by reusable-attest-scan.yml. Verdict rule: the gate FAILS if any result has level \"error\" or a security-severity of high/critical; otherwise it PASSES. Verifiers MUST read runs[].results to determine the verdict — a valid signature proves the gate ran and was recorded, not that it passed.",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "version": { "const": "2.1.0" },
+    "$schema": { "type": "string" },
+    "runs": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/docs/reference/attestation-predicates/sca/v1/schema.json
+++ b/docs/reference/attestation-predicates/sca/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/sca/v1",
+  "title": "zircote SCA gate predicate (OSV-Scanner, SARIF 2.1.0)",
+  "description": "Predicate body is the unmodified SARIF 2.1.0 log produced by OSV-Scanner and signed by reusable-attest-scan.yml. Verdict rule: the gate FAILS if any result reports a vulnerability at or above the configured severity threshold; otherwise it PASSES. Verifiers MUST read runs[].results — signature validity is not a pass.",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "version": { "const": "2.1.0" },
+    "$schema": { "type": "string" },
+    "runs": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/docs/reference/attestation-predicates/scorecard/v1/schema.json
+++ b/docs/reference/attestation-predicates/scorecard/v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zircote.github.io/attestations/scorecard/v1",
+  "title": "zircote supply-chain posture gate predicate (OpenSSF Scorecard, SARIF 2.1.0)",
+  "description": "Predicate body is the unmodified SARIF 2.1.0 log produced by OpenSSF Scorecard and signed by reusable-attest-scan.yml. Posture is advisory by default: the gate records each check's score (0-10). Verifiers read runs[].results to enforce a minimum aggregate or per-check score; signature validity is not a pass.",
+  "type": "object",
+  "required": ["version", "runs"],
+  "properties": {
+    "version": { "const": "2.1.0" },
+    "$schema": { "type": "string" },
+    "runs": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -275,8 +275,30 @@ on them):
 | Grype (`anchore/scan-action`) | v7.4.0 |
 | `actions/attest-build-provenance` | v4.1.0 |
 
+## Attested quality-gate workflows
+
+A sibling suite (constituted by the [`gh-attested`
+skill](../../.github/skills/gh-attested/SKILL.md)) brings a public OSS repo to
+complete CI quality-gate coverage and signs each gate's verdict as a custom-
+predicate attestation. Full per-workflow inputs live in the skill's
+`references/gate-catalog.md`; the CLAUDE.md "Attested Quality Gates" section is
+the index.
+
+| Workflow | Gate |
+| --- | --- |
+| `reusable-attest-scan.yml` | the seam — signs any evidence file by digest |
+| `reusable-sast-codeql.yml` | SAST (CodeQL) |
+| `reusable-sca-osv.yml` | SCA (OSV-Scanner + dependency review) |
+| `reusable-trivy.yml` | container vuln + IaC misconfig + license |
+| `reusable-scorecard.yml` | supply-chain posture (OpenSSF Scorecard) |
+| `reusable-vex.yml` | vulnerability disposition (OpenVEX) |
+| `reusable-k6.yml` | load / performance (opt-in) |
+| `reusable-zap.yml` | DAST (OWASP ZAP, opt-in) |
+| `reusable-verify-gates.yml` | fail-closed verify before deploy |
+
 ## See also
 
 - [Onboard a repo to attested delivery](../how-to/onboard-a-repo-to-attested-delivery.md)
+- [Onboard a repo to attested quality gates](../how-to/onboard-a-repo-to-attested-quality-gates.md)
 - [Why attested delivery](../explanation/attested-delivery.md)
 - [Rollout status](../attested-delivery/rollout-status.md)


### PR DESCRIPTION
## Summary

Constitutes the **attested quality-gate** suite from the corpus guide *GitHub-Native Attested Quality Gates* (free-for-OSS). Every enterprise CI gate is wired as a central reusable workflow whose verdict can be turned into a **signed, digest-bound attestation** via GitHub keyless signing. Adds the `gh-attested` skill (assess → plan → implement) and the nine central workflows, **composing with** `attested-delivery`, `reusable-security.yml`, and `sbom-and-scan.yml` rather than duplicating them.

## What's included

**Skill** — `.github/skills/gh-attested/`
- `SKILL.md` (assess → plan → implement → enforce → verify protocol)
- 7 references: gate-catalog, assessment, attestation-seam, enforcement, verification, repo-config, limitations
- `__org__`-parameterized templates: caller, `ruleset.json`, `dependabot.yml`, `CODEOWNERS`, secrets guidance, SECURITY snippet, + copies of the 9 workflows

**Central reusable workflows** — `.github/workflows/`
- `reusable-attest-scan.yml` — the custom-predicate signing **seam**
- `-sast-codeql`, `-sca-osv`, `-trivy`, `-scorecard`, `-vex`, `-k6`, `-zap`, `-verify-gates`

**Repo-config safety contract** — auto-apply (ruleset/settings/native scanners/environments) with diff-preview + confirm; secrets/variables **guided, never written or logged**.

**Docs** — CLAUDE.md section + table, SECURITY.md "Verifying Quality-Gate Attestations", a Diátaxis how-to, reference/index updates.

## Validation
- `actionlint` — exit 0 on all 9 workflows + caller template
- pin-check logic replicated over the 9 workflows — **all pinned, zero violations**
- Trivy pinned to a **maintainer-signed post-CVE-2026-33634 commit** (verified)
- OSV reusable path verified present at the pinned SHA
- Skill structure validated: frontmatter, all references resolve, templates parameterized (no `zircote` leaks), `ruleset.json` valid JSON
- **pin-check reused (not duplicated)** and wired as a required status check

## Not done in this PR (by design)
Live dispatch dry-run + independent `gh attestation verify` is the **post-merge acceptance test** — it needs the workflows live on a callable ref first. Run it after merge per the skill's `references/verification.md`.

## Boundaries (faithful to the guide)
Private repos need GHAS licenses for CodeQL/secret-scanning/dependency-review; GitHub has no k8s admission control (external — Kyverno/policy-controller); no standard performance predicate; **a signed attestation proves a gate ran and recorded a verdict, not that it passed**.

