### PR TITLE
fix(scripts): escape backslashes before pipes (CodeQL alert #1)

### DIFF
--- a/scripts/generate-readme-sections.js
+++ b/scripts/generate-readme-sections.js
@@ -53,7 +53,11 @@ function generateTopReposMarkdown(repos) {
   const rows = repos.map(repo => {
     const name = repo.name;
     const url = repo.url;
-    const desc = truncate(repo.description || 'No description', 55).replace(/\|/g, '\\|');
+    // Escape backslashes before pipes so a literal "\|" in a description can't
+    // defeat the table-cell pipe escaping (CodeQL js/incomplete-sanitization).
+    const desc = truncate(repo.description || 'No description', 55)
+      .replace(/\\/g, '\\\\')
+      .replace(/\|/g, '\\|');
     const lang = repo.language || 'Mixed';
     const emoji = getActivityEmoji(repo.score);
 


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning **alert #1** — `js/incomplete-sanitization` (high) in `scripts/generate-readme-sections.js:56`.

`generateTopReposMarkdown` escaped `|` → `\|` for the markdown table cell but **did not escape backslashes first**. A description containing `\|` (backslash + pipe) became `\\|`: the backslash escapes itself, leaving the pipe **unescaped** — which breaks the table row (and is the injection the rule flags).

## Fix

Escape `\` → `\\` **before** `|` → `\|` (correct order):

```js
.replace(/\\/g, '\\\\')
.replace(/\|/g, '\\|');
```

## Verification

- `node --check` passes.
- Escaping proof (unescaped-pipe count in output):

| input | old | new |
|-------|-----|-----|
| `plain` | 0 | 0 |
| `a\|b` | 0 | 0 |
| `a\\\|b` | **1** | 0 |
| `\\\|` | **1** | 0 |
| trailing `\\` | 0 | 0 |

The two table-breaking cases drop from 1 unescaped pipe to 0; benign cases unchanged. CodeQL will re-scan on merge and close the alert.

Note: line 79 (`generateNewReposMarkdown`) interpolates the description into a markdown **list item**, not a pipe-delimited table, so it has no delimiter-injection issue and is intentionally left as-is.
