### PR TITLE
fix(gh-attested): expose gate SARIF as artifacts so the attestation seam connects

### DIFF
--- a/.github/skills/gh-attested/references/attestation-seam.md
+++ b/.github/skills/gh-attested/references/attestation-seam.md
@@ -22,7 +22,7 @@ Three actions cover the common predicates; one covers everything else:
 ## The central seam workflow
 
 `reusable-attest-scan.yml` wraps `actions/attest`. It downloads an evidence
-artifact (uploaded by the gate job) and signs the named file as a custom
+artifact (uploaded by the gate reusable) and signs the named file as a custom
 predicate bound to `subject-digest`. Because it is a *central reusable
 workflow*, the Fulcio SAN is the central signer — SLSA L3 isolation — and
 verifiers pin `--signer-workflow`.
@@ -39,13 +39,27 @@ attest-sast:
     subject-name: ghcr.io/zircote/app
     subject-digest: ${{ needs.build.outputs.digest }}
     predicate-type: https://zircote.github.io/attestations/sast/v1
-    predicate-artifact: codeql-sarif      # uploaded by the sast job
-    predicate-filename: results.sarif
+    predicate-artifact: ${{ needs.sast.outputs.sarif-artifact }}
+    predicate-filename: ${{ needs.sast.outputs.sarif-filename }}
 ```
 
-The gate job must `actions/upload-artifact` its evidence file under
-`predicate-artifact` so the seam job can download it (reusable workflows do not
-share a filesystem across caller jobs).
+Each SARIF gate reusable uploads its evidence as a downloadable artifact and
+exposes two `workflow_call` outputs — `sarif-artifact` (the artifact name) and
+`sarif-filename` (the file within it) — so the seam consumes them directly with
+no caller-side upload step. (`reusable-attest-scan.yml` downloads that artifact;
+reusable workflows do not share a filesystem across caller jobs.)
+
+| Gate reusable | `sarif-artifact` | `sarif-filename` |
+|---|---|---|
+| `reusable-sast-codeql.yml` | `sast-sarif` | `results.sarif` |
+| `reusable-sca-osv.yml` | `OSV Scanner SARIF file` | `results.sarif` |
+| `reusable-scorecard.yml` | `scorecard-sarif` | `scorecard.sarif` |
+| `reusable-trivy.yml` (iac/license) | `iac-license-sarif` | `trivy-iac-license.sarif` |
+| `reusable-trivy.yml` (image) | `container-scan-sarif` ¹ | `trivy-image.sarif` ¹ |
+
+¹ The Trivy image scan exposes its SARIF via the `image-sarif-artifact` /
+`image-sarif-filename` outputs (the `sarif-artifact` / `sarif-filename` outputs
+carry the always-present IaC+license scan).
 
 ## Predicate-type URIs
 

--- a/.github/skills/gh-attested/templates/reusable-attest-scan.yml
+++ b/.github/skills/gh-attested/templates/reusable-attest-scan.yml
@@ -18,7 +18,7 @@
 # Usage:
 #   jobs:
 #     attest-sast:
-#       needs: [sast]
+#       needs: [build, sast]   # build emits the subject digest; sast the SARIF
 #       permissions:
 #         id-token: write
 #         attestations: write
@@ -28,8 +28,8 @@
 #         subject-name: my-app
 #         subject-digest: ${{ needs.build.outputs.digest }}   # sha256:...
 #         predicate-type: https://__org__.github.io/attestations/sast/v1
-#         predicate-artifact: codeql-sarif
-#         predicate-filename: results.sarif
+#         predicate-artifact: ${{ needs.sast.outputs.sarif-artifact }}
+#         predicate-filename: ${{ needs.sast.outputs.sarif-filename }}
 
 name: attest-scan
 

--- a/.github/skills/gh-attested/templates/reusable-sast-codeql.yml
+++ b/.github/skills/gh-attested/templates/reusable-sast-codeql.yml
@@ -46,6 +46,13 @@ on:
         required: false
         type: string
         default: ''
+    outputs:
+      sarif-artifact:
+        description: 'Artifact name holding the SARIF evidence (attestation seam)'
+        value: sast-sarif
+      sarif-filename:
+        description: 'SARIF filename within the artifact'
+        value: results.sarif
 
 permissions:
   contents: read
@@ -75,3 +82,32 @@ jobs:
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           category: '/language:${{ inputs.languages }}'
+          # Write SARIF to a directory in addition to the code-scanning upload,
+          # so the attestation seam can sign it bound to a release subject.
+          output: codeql-sarif
+
+      # CodeQL writes one SARIF per language; merge their runs into a single
+      # results.sarif and expose it as a downloadable artifact for the seam.
+      - name: Merge SARIF for attestation
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(codeql-sarif/*.sarif)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::CodeQL produced no SARIF"; exit 1
+          fi
+          jq -s '{
+            "$schema": .[0]."$schema",
+            "version": .[0].version,
+            "runs": (map(.runs) | add)
+          }' "${files[@]}" > results.sarif
+          jq -e . results.sarif > /dev/null
+
+      - name: Upload SAST SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sast-sarif
+          path: results.sarif
+          if-no-files-found: error

--- a/.github/skills/gh-attested/templates/reusable-sca-osv.yml
+++ b/.github/skills/gh-attested/templates/reusable-sca-osv.yml
@@ -38,6 +38,15 @@ on:
         default: |-
           --recursive
           ./
+    outputs:
+      # The OSV reusable (pinned by SHA above) uploads its SARIF under this
+      # fixed artifact name; the attestation seam downloads it by this name.
+      sarif-artifact:
+        description: 'Artifact name holding the OSV SARIF (attestation seam)'
+        value: 'OSV Scanner SARIF file'
+      sarif-filename:
+        description: 'SARIF filename within the artifact'
+        value: results.sarif
 
 permissions:
   contents: read

--- a/.github/skills/gh-attested/templates/reusable-scorecard.yml
+++ b/.github/skills/gh-attested/templates/reusable-scorecard.yml
@@ -29,6 +29,13 @@ on:
         required: false
         type: boolean
         default: true
+    outputs:
+      sarif-artifact:
+        description: 'Artifact name holding the SARIF evidence (attestation seam)'
+        value: scorecard-sarif
+      sarif-filename:
+        description: 'SARIF filename within the artifact'
+        value: scorecard.sarif
 
 permissions:
   contents: read
@@ -60,3 +67,13 @@ jobs:
         with:
           sarif_file: scorecard.sarif
           category: scorecard
+
+      # Expose the SARIF as a downloadable artifact so the attestation seam
+      # (reusable-attest-scan.yml) can sign it bound to a release subject.
+      - name: Upload Scorecard SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: scorecard.sarif
+          if-no-files-found: error

--- a/.github/skills/gh-attested/templates/reusable-trivy.yml
+++ b/.github/skills/gh-attested/templates/reusable-trivy.yml
@@ -44,6 +44,19 @@ on:
         required: false
         type: boolean
         default: true
+    outputs:
+      sarif-artifact:
+        description: 'Artifact name holding the IaC+license SARIF (attestation seam)'
+        value: iac-license-sarif
+      sarif-filename:
+        description: 'IaC+license SARIF filename within the artifact'
+        value: trivy-iac-license.sarif
+      image-sarif-artifact:
+        description: 'Artifact name holding the image-scan SARIF (when image-ref set)'
+        value: container-scan-sarif
+      image-sarif-filename:
+        description: 'Image-scan SARIF filename within the artifact'
+        value: trivy-image.sarif
 
 permissions:
   contents: read
@@ -79,6 +92,15 @@ jobs:
           sarif_file: trivy-iac-license.sarif
           category: trivy-iac-license
 
+      # Expose the SARIF as a downloadable artifact for the attestation seam.
+      - name: Upload IaC + license SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: iac-license-sarif
+          path: trivy-iac-license.sarif
+          if-no-files-found: error
+
   image:
     name: image
     if: ${{ inputs.image-ref != '' }}
@@ -105,3 +127,12 @@ jobs:
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
+
+      # Expose the SARIF as a downloadable artifact for the attestation seam.
+      - name: Upload image SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: container-scan-sarif
+          path: trivy-image.sarif
+          if-no-files-found: error

--- a/.github/workflows/reusable-attest-scan.yml
+++ b/.github/workflows/reusable-attest-scan.yml
@@ -18,7 +18,7 @@
 # Usage:
 #   jobs:
 #     attest-sast:
-#       needs: [sast]
+#       needs: [build, sast]   # build emits the subject digest; sast the SARIF
 #       permissions:
 #         id-token: write
 #         attestations: write
@@ -28,8 +28,8 @@
 #         subject-name: my-app
 #         subject-digest: ${{ needs.build.outputs.digest }}   # sha256:...
 #         predicate-type: https://zircote.github.io/attestations/sast/v1
-#         predicate-artifact: codeql-sarif
-#         predicate-filename: results.sarif
+#         predicate-artifact: ${{ needs.sast.outputs.sarif-artifact }}
+#         predicate-filename: ${{ needs.sast.outputs.sarif-filename }}
 
 name: attest-scan
 

--- a/.github/workflows/reusable-sast-codeql.yml
+++ b/.github/workflows/reusable-sast-codeql.yml
@@ -46,6 +46,13 @@ on:
         required: false
         type: string
         default: ''
+    outputs:
+      sarif-artifact:
+        description: 'Artifact name holding the SARIF evidence (attestation seam)'
+        value: sast-sarif
+      sarif-filename:
+        description: 'SARIF filename within the artifact'
+        value: results.sarif
 
 permissions:
   contents: read
@@ -75,3 +82,32 @@ jobs:
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           category: '/language:${{ inputs.languages }}'
+          # Write SARIF to a directory in addition to the code-scanning upload,
+          # so the attestation seam can sign it bound to a release subject.
+          output: codeql-sarif
+
+      # CodeQL writes one SARIF per language; merge their runs into a single
+      # results.sarif and expose it as a downloadable artifact for the seam.
+      - name: Merge SARIF for attestation
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(codeql-sarif/*.sarif)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::CodeQL produced no SARIF"; exit 1
+          fi
+          jq -s '{
+            "$schema": .[0]."$schema",
+            "version": .[0].version,
+            "runs": (map(.runs) | add)
+          }' "${files[@]}" > results.sarif
+          jq -e . results.sarif > /dev/null
+
+      - name: Upload SAST SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sast-sarif
+          path: results.sarif
+          if-no-files-found: error

--- a/.github/workflows/reusable-sca-osv.yml
+++ b/.github/workflows/reusable-sca-osv.yml
@@ -38,6 +38,15 @@ on:
         default: |-
           --recursive
           ./
+    outputs:
+      # The OSV reusable (pinned by SHA above) uploads its SARIF under this
+      # fixed artifact name; the attestation seam downloads it by this name.
+      sarif-artifact:
+        description: 'Artifact name holding the OSV SARIF (attestation seam)'
+        value: 'OSV Scanner SARIF file'
+      sarif-filename:
+        description: 'SARIF filename within the artifact'
+        value: results.sarif
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -29,6 +29,13 @@ on:
         required: false
         type: boolean
         default: true
+    outputs:
+      sarif-artifact:
+        description: 'Artifact name holding the SARIF evidence (attestation seam)'
+        value: scorecard-sarif
+      sarif-filename:
+        description: 'SARIF filename within the artifact'
+        value: scorecard.sarif
 
 permissions:
   contents: read
@@ -60,3 +67,13 @@ jobs:
         with:
           sarif_file: scorecard.sarif
           category: scorecard
+
+      # Expose the SARIF as a downloadable artifact so the attestation seam
+      # (reusable-attest-scan.yml) can sign it bound to a release subject.
+      - name: Upload Scorecard SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: scorecard.sarif
+          if-no-files-found: error

--- a/.github/workflows/reusable-trivy.yml
+++ b/.github/workflows/reusable-trivy.yml
@@ -44,6 +44,19 @@ on:
         required: false
         type: boolean
         default: true
+    outputs:
+      sarif-artifact:
+        description: 'Artifact name holding the IaC+license SARIF (attestation seam)'
+        value: iac-license-sarif
+      sarif-filename:
+        description: 'IaC+license SARIF filename within the artifact'
+        value: trivy-iac-license.sarif
+      image-sarif-artifact:
+        description: 'Artifact name holding the image-scan SARIF (when image-ref set)'
+        value: container-scan-sarif
+      image-sarif-filename:
+        description: 'Image-scan SARIF filename within the artifact'
+        value: trivy-image.sarif
 
 permissions:
   contents: read
@@ -79,6 +92,15 @@ jobs:
           sarif_file: trivy-iac-license.sarif
           category: trivy-iac-license
 
+      # Expose the SARIF as a downloadable artifact for the attestation seam.
+      - name: Upload IaC + license SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: iac-license-sarif
+          path: trivy-iac-license.sarif
+          if-no-files-found: error
+
   image:
     name: image
     if: ${{ inputs.image-ref != '' }}
@@ -105,3 +127,12 @@ jobs:
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
+
+      # Expose the SARIF as a downloadable artifact for the attestation seam.
+      - name: Upload image SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: container-scan-sarif
+          path: trivy-image.sarif
+          if-no-files-found: error


### PR DESCRIPTION
## Problem

The attestation seam (`reusable-attest-scan.yml`) consumes an evidence artifact by **name** (`actions/download-artifact`), but the SARIF gate reusables (`reusable-sast-codeql`, `-sca-osv`, `-trivy`, `-scorecard`) only pushed their SARIF to the code-scanning hub — none uploaded a downloadable artifact, and none exposed `workflow_call` outputs. `references/attestation-seam.md`'s example wired `predicate-artifact: codeql-sarif # uploaded by the sast job`, an upload the reusables never performed. The seam therefore could not be wired as a thin caller of the central reusables.

## Fix

Each SARIF gate reusable now uploads its SARIF as a downloadable artifact and exposes `sarif-artifact` / `sarif-filename` `workflow_call` outputs:

- **reusable-sast-codeql.yml** — `analyze` writes SARIF to a dir; a merge step concatenates per-language `runs[]` into `results.sarif`; uploads as `sast-sarif`.
- **reusable-trivy.yml** — uploads the iac-license SARIF (`iac-license-sarif`) and, when `image-ref` is set, the image SARIF (`container-scan-sarif`).
- **reusable-scorecard.yml** — uploads `scorecard-sarif`.
- **reusable-sca-osv.yml** — OSV already uploads `OSV Scanner SARIF file`; exposed via outputs only (no new step).

`references/attestation-seam.md` and the seam usage comment now wire `predicate-artifact` / `predicate-filename` from those outputs, plus a gate→outputs table. Applied to both the live reusables and the `gh-attested` skill template copies.

## Compatibility

Additive only — existing hub uploads and gate behavior are unchanged; the new artifacts/outputs are extra. All new `uses:` are full-SHA pinned (`upload-artifact@043fb46d…`). actionlint clean.
