### PR TITLE
feat(release): attest SBOM + vulnerability scan to the source release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,4 +185,4 @@ jobs:
               exit 1
             fi
           done
-          exit 1
+          echo "All attestations verified (provenance, SBOM, vuln)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,24 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Source-germane evidence generated from the pristine checkout (before the
+      # bundle tarball exists, so Syft does not catalog the archive itself);
+      # attested to the bundle digest further down.
+      - name: Generate source SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Scan source for vulnerabilities (Grype)
+        id: grype
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          path: .
+          output-format: json
+          fail-build: false   # evidence to attest, not a gate (read the verdict)
+
       - name: Build deterministic source bundle
         id: bundle
         env:
@@ -93,6 +111,23 @@ jobs:
         with:
           subject-path: ${{ steps.bundle.outputs.artifact }}
 
+      # The source-germane gates: the SBOM + vuln evidence generated above from
+      # the pristine checkout, each attested to the SAME bundle digest. These
+      # describe the package (its deps and vulnerabilities), not a container.
+      - name: Attest the SBOM to the bundle
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ steps.bundle.outputs.artifact }}
+          predicate-type: https://cyclonedx.org/bom
+          predicate-path: sbom.cdx.json
+
+      - name: Attest the vulnerability report to the bundle
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ steps.bundle.outputs.artifact }}
+          predicate-type: https://in-toto.io/attestation/vulns/v0.1
+          predicate-path: ${{ steps.grype.outputs.json }}
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -100,15 +135,18 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
           ARTIFACT: ${{ steps.bundle.outputs.artifact }}
           PRERELEASE: ${{ steps.tag.outputs.prerelease }}
+          GRYPE_JSON: ${{ steps.grype.outputs.json }}
         run: |
           PRE_FLAG=""
           [ "$PRERELEASE" = "true" ] && PRE_FLAG="--prerelease"
+          # Carry the evidence files alongside the bundle (stable names).
+          cp "$GRYPE_JSON" grype.json
+          ASSETS=("$ARTIFACT" "$ARTIFACT.sha256" sbom.cdx.json grype.json)
           # Idempotent: a re-dispatch against an existing tag refreshes the
           # release assets instead of failing on an already-published release.
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists; refreshing assets."
-            gh release upload "$TAG" "$ARTIFACT" "$ARTIFACT.sha256" \
-              --repo "$REPO" --clobber
+            gh release upload "$TAG" "${ASSETS[@]}" --repo "$REPO" --clobber
           else
             gh release create "$TAG" \
               --repo "$REPO" \
@@ -116,25 +154,35 @@ jobs:
               --generate-notes \
               --verify-tag \
               $PRE_FLAG \
-              "$ARTIFACT" "$ARTIFACT.sha256"
+              "${ASSETS[@]}"
           fi
 
-      - name: Verify the attestation (fail-closed dogfood)
+      - name: Verify the attestations (fail-closed dogfood)
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ARTIFACT: ${{ steps.bundle.outputs.artifact }}
         run: |
           SIGNER="${REPO}/.github/workflows/release.yml"
-          # Tolerate brief attestation-index propagation, but fail closed.
-          for attempt in 1 2 3 4 5; do
-            if gh attestation verify "$ARTIFACT" \
-                 --repo "$REPO" --signer-workflow "$SIGNER"; then
-              echo "Attestation verified on attempt $attempt."
-              exit 0
+          # Verifies every attestation this workflow signed for the bundle —
+          # provenance, SBOM, and vuln. Tolerates brief attestation-index
+          # propagation, but fails closed.
+          for pt in https://slsa.dev/provenance/v1 \
+                    https://cyclonedx.org/bom \
+                    https://in-toto.io/attestation/vulns/v0.1; do
+            ok=""
+            for attempt in 1 2 3 4 5; do
+              if gh attestation verify "$ARTIFACT" --repo "$REPO" \
+                   --signer-workflow "$SIGNER" --predicate-type "$pt"; then
+                echo "Verified $pt (attempt $attempt)."
+                ok=1; break
+              fi
+              echo "$pt not yet verifiable (attempt $attempt); retrying in 10s..."
+              sleep 10
+            done
+            if [ -z "$ok" ]; then
+              echo "::error::Attestation $pt did not verify — refusing to leave an unverified release."
+              exit 1
             fi
-            echo "Not yet verifiable (attempt $attempt); retrying in 10s..."
-            sleep 10
           done
-          echo "::error::Attestation did not verify — refusing to leave an unverified release."
           exit 1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,10 +24,15 @@ The `release` workflow then:
 
 1. Validates the tag is semver (fails closed otherwise).
 2. Builds `zircote-github-<version>.tar.gz` with `git archive` (reproducible).
-3. Attests SLSA build provenance over the bundle (`actions/attest-build-provenance`).
-4. Creates the GitHub Release with auto-generated notes and attaches the bundle
-   plus its `.sha256`.
-5. Re-verifies the attestation fail-closed before finishing.
+3. Attests three predicates to the bundle digest:
+   - **SLSA build provenance** (`https://slsa.dev/provenance/v1`) — how it was built;
+   - **CycloneDX SBOM** (`https://cyclonedx.org/bom`) — the package's declared
+     dependencies (Syft over the source);
+   - **Vulnerability report** (`https://in-toto.io/attestation/vulns/v0.1`) — a
+     Grype scan of the source (evidence, not a gate — read the verdict).
+4. Creates the GitHub Release with auto-generated notes and attaches the bundle,
+   its `.sha256`, `sbom.cdx.json`, and `grype.json`.
+5. Re-verifies all three attestations fail-closed before finishing.
 
 To re-run against an existing tag, dispatch the workflow manually
 (**Actions → release → Run workflow**) and supply the tag. A re-dispatch is
@@ -44,12 +49,26 @@ Download the `.tar.gz` from the release, then — independently from a
 workstation:
 
 ```bash
-gh attestation verify zircote-github-<version>.tar.gz \
-  --repo zircote/.github \
-  --signer-workflow zircote/.github/.github/workflows/release.yml
+BUNDLE=zircote-github-<version>.tar.gz
+SIGNER=zircote/.github/.github/workflows/release.yml
+
+# Provenance — how it was built (omit --predicate-type to verify all three)
+gh attestation verify "$BUNDLE" --repo zircote/.github --signer-workflow "$SIGNER" \
+  --predicate-type https://slsa.dev/provenance/v1
+
+# SBOM — the package's declared dependencies
+gh attestation verify "$BUNDLE" --repo zircote/.github --signer-workflow "$SIGNER" \
+  --predicate-type https://cyclonedx.org/bom
+
+# Vulnerability report — read the verdict, don't just trust the signature
+gh attestation verify "$BUNDLE" --repo zircote/.github --signer-workflow "$SIGNER" \
+  --predicate-type https://in-toto.io/attestation/vulns/v0.1
 ```
 
 `--signer-workflow` is required: under SLSA L3 the Fulcio SAN is the signing
-workflow. Inspect the provenance predicate with `--format json | jq` to confirm
-the source commit and build inputs. A successful verify proves the bundle is
-authentic and unmodified since it was built from the tag.
+workflow, not the source repo. A successful verify proves the bundle is
+authentic and bound to that predicate — **not** that the vuln scan was clean;
+inspect the predicate body (`--format json | jq`) to read the verdict. These
+predicates describe the **package** (its provenance, dependencies, and
+vulnerabilities), which is why they apply to a source release, not only to a
+container image.


### PR DESCRIPTION
## Summary

You flagged that most of the security checks are germane to the **package/source**, not only a container image — correct. This wires the minimum you asked for (**SBOM and vuln**) onto the source release.

`release.yml` now attests **three** predicates to the release bundle digest, all signed by `release.yml`:

| Predicate | URI | Describes |
|-----------|-----|-----------|
| Provenance | `https://slsa.dev/provenance/v1` | how the bundle was built (existing) |
| SBOM | `https://cyclonedx.org/bom` | the package's declared dependencies (Syft over source) |
| Vulnerabilities | `https://in-toto.io/attestation/vulns/v0.1` | Grype scan of the source (evidence, read the verdict) |

- SBOM + scan run on the **pristine checkout**, before the tarball exists (so Syft doesn't catalog the archive itself).
- The fail-closed self-verify step now checks **all three** predicates.
- `sbom.cdx.json` and `grype.json` are attached to the Release.
- `RELEASING.md` updated with per-predicate verify commands and the package-vs-container framing.

## Type of Change

- [x] New feature (non-breaking) — adds SBOM + vuln attestations to the release
- [x] Documentation update

## Test Plan

- [x] `actionlint` clean on `release.yml`
- [x] All six actions SHA-pinned (reuses repo's existing anchore/attest pins)
- [ ] Exercised end-to-end — runs only on tag push; will be validated by cutting the next tag (e.g. `v0.1.1`) after merge

## Checklist

- [x] Self-reviewed; step order is scan-pristine → bundle → attest(3) → release → verify
- [x] Follows project conventions (SHA-pinned, least-privilege; job already has `id-token`/`attestations: write`)
- [x] Docs updated (`RELEASING.md`)
- [x] No new warnings (actionlint clean)
