### PR TITLE
chore: add lefthook git hooks (actionlint, merge-markers, pin-check)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,29 @@
+# Git hooks for zircote/.github, managed by lefthook (https://lefthook.dev).
+#
+# Purpose: catch locally what the GitHub Actions CI gates reject on push —
+# malformed workflows (actionlint) and unpinned action references (pin-check) —
+# so a push doesn't round-trip through a red CI run.
+#
+# One-time setup after clone:   lefthook install
+# Bypass in an emergency:       git commit --no-verify  /  git push --no-verify
+
+pre-commit:
+  parallel: true
+  commands:
+    # Lint only the workflow files being committed (fast, <1s each).
+    actionlint:
+      glob: ".github/workflows/*.yml"
+      run: actionlint {staged_files}
+      fail_text: "actionlint found workflow errors — fix them before committing."
+
+    # Prevent committing unresolved merge-conflict markers.
+    merge-conflicts:
+      run: scripts/check-merge-markers.sh {staged_files}
+      fail_text: "Unresolved merge-conflict markers in staged files."
+
+pre-push:
+  commands:
+    # Mirror of the required CI pin-check gate; scans .github/workflows + actions.
+    pin-check:
+      run: scripts/check-pins.sh
+      fail_text: "Unpinned GitHub Actions references — the CI pin-check gate will reject this push."

--- a/scripts/check-merge-markers.sh
+++ b/scripts/check-merge-markers.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Block commits that contain unresolved merge-conflict markers in staged files.
+# Args: the staged file paths (passed by lefthook as {staged_files}).
+# Checks only the unambiguous `<<<<<<<` / `>>>>>>>` line starts (a bare
+# `=======` is a common Markdown/RST rule, so it is intentionally not flagged).
+#
+# Bypass in an emergency:  git commit --no-verify
+set -euo pipefail
+[ "$#" -eq 0 ] && exit 0
+
+hits=$(grep -lE '^(<<<<<<<|>>>>>>>)' "$@" 2>/dev/null || true)
+if [ -n "$hits" ]; then
+  echo "Unresolved merge-conflict markers in:"
+  echo "$hits" | sed 's/^/  /'
+  echo "Resolve the conflicts, then re-stage and commit."
+  exit 1
+fi

--- a/scripts/check-pins.sh
+++ b/scripts/check-pins.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Local mirror of the CI pin-check gate (.github/workflows/pin-check.yml):
+# assert every GitHub Actions `uses:` is pinned to a full 40-char commit SHA.
+#
+# Scans the SAME dirs as pin-check-ci.yml (.github/workflows + actions) so it
+# does not false-positive on the illustrative `uses: …@v6` lines inside
+# .github/skills/**/*.md, which are documentation, not executable.
+#
+# Local reusable-workflow calls (`uses: ./...`) and digest-pinned container
+# actions (`uses: docker://...@sha256:...`) are exempt.
+#
+# Bypass in an emergency:  git push --no-verify
+set -euo pipefail
+
+rc=0
+for SCAN_DIR in .github/workflows actions; do
+  [ -d "$SCAN_DIR" ] || continue
+  while IFS= read -r hit; do
+    file="${hit%%:*}"; rest="${hit#*:}"
+    lineno="${rest%%:*}"; content="${rest#*:}"
+    # Isolate the `uses:` value: drop up to `uses:`, ltrim, keep the first token
+    # only — so inline comments cannot influence the check.
+    value="${content#*uses:}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%%[[:space:]]*}"
+    case "$value" in
+      ./*) continue ;;                  # local reusable workflow
+      docker://*@sha256:*) continue ;;  # digest-pinned container action
+    esac
+    ref="${value##*@}"
+    if ! printf '%s' "$ref" | grep -Eq '^[0-9a-f]{40}$'; then
+      echo "  ✗ ${file}:${lineno}  unpinned: ${value}"
+      rc=1
+    fi
+  done < <(grep -rnE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+@' "$SCAN_DIR" || true)
+done
+
+if [ "$rc" -ne 0 ]; then
+  echo ""
+  echo "ERROR: unpinned action references found — the CI pin-check gate will reject this push."
+  echo "Fix: replace each @tag with the action's full 40-char commit SHA (keep the version as a comment)."
+  echo "Bypass (emergency): git push --no-verify"
+else
+  echo "pin-check: all action references under .github/workflows and actions are SHA-pinned."
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary

Provisioned project-tailored git hooks via **lefthook** (already on PATH; no Node/Python runtime). The hooks catch locally exactly what this repo's CI gates reject on push.

| Stage | Hook | What it catches | Tool |
|-------|------|-----------------|------|
| pre-commit | `actionlint` | malformed workflow YAML (on staged `.github/workflows/*.yml`) | installed `actionlint` |
| pre-commit | `merge-conflicts` | unresolved `<<<<<<<`/`>>>>>>>` markers | grep |
| pre-push | `pin-check` | unpinned `uses:` refs — mirror of the **required** CI gate | `scripts/check-pins.sh` |

`scripts/check-pins.sh` mirrors `.github/workflows/pin-check.yml` exactly and scans the **same dirs as `pin-check-ci.yml`** (`.github/workflows` + `actions`) — so it does not false-positive on the illustrative `uses: …@v6` lines in `.github/skills/**/*.md`.

## Validated live (not just asserted)

- This branch's **commit** fired `merge-conflicts` → passed (actionlint correctly skipped — no workflow files staged).
- This branch's **push** fired `pin-check` → passed ("all action references SHA-pinned", ~2.5s).
- pin-check unit-tested both ways: clean repo → exit 0; injected `@v4` → exit 1 with an actionable message.

## Deliberately NOT installed (with reasons)

- **creep** (AI-authorship trailers) — `git-creep` is on PATH, but the global `CLAUDE.md` rule "No AI Attribution: Do NOT add Co-Authored-By or similar AI attribution lines" forbids the `AI-Tool`/`AI-Model` trailers it stamps.
- **gh-aw compile sync** — `gh aw` is not installed, and this repo compiles to `.lock.yml` via `scripts/compile-gh-aw.sh` (not the generic `gh aw compile → .yml`). Worth adding once `gh aw` is installed.
- **gitleaks secrets** — binary not installed locally (auto-mode only uses already-installed tools; gitleaks runs in CI via `reusable-security.yml`).

## Team setup

After clone: `lefthook install`. Bypass in an emergency: `git commit --no-verify` / `git push --no-verify`.

## Type of Change
- [x] Chore (tooling)

## Test Plan
- [x] `lefthook install` wires pre-commit + pre-push shims
- [x] pin-check: clean→0, unpinned→1; same logic/scope as CI
- [x] merge-markers: clean→0, conflict→1
- [x] actionlint clean on workflows
- [x] commit + push of this branch exercised both hooks live
