### PR TITLE
feat(reusable-trivy): add ignore-unfixed input for base-image gating

### DIFF
--- a/.github/workflows/reusable-trivy.yml
+++ b/.github/workflows/reusable-trivy.yml
@@ -44,6 +44,15 @@ on:
         required: false
         type: boolean
         default: true
+      ignore-unfixed:
+        description: >-
+          Only report/fail on vulnerabilities that have a fix available.
+          Standard posture for base-image gating: distroless/Debian images
+          carry unfixed glibc/openssl CVEs with no upstream patch, which
+          would otherwise fail the image gate forever with nothing actionable.
+        required: false
+        type: boolean
+        default: false
     outputs:
       sarif-artifact:
         description: 'Artifact name holding the IaC+license SARIF (attestation seam)'
@@ -119,6 +128,7 @@ jobs:
           format: sarif
           output: trivy-image.sarif
           severity: ${{ inputs.severity }}
+          ignore-unfixed: ${{ inputs.ignore-unfixed }}
           exit-code: '1'   # fail-closed on image vulnerabilities
 
       - name: Upload image SARIF


### PR DESCRIPTION
Adds an opt-in `ignore-unfixed` input (default `false`) to `reusable-trivy.yml`, wired to the image vulnerability scan. Gates on **fixable** vulnerabilities only — the standard posture for distroless/Debian base images (unfixed glibc/openssl/gcc CVEs with no upstream patch). Default preserves behavior for all current callers. Surfaced by nsip's v0.7.0 release (image gate failed on 8 unfixed base-image CVEs).