### PR TITLE
fix(sign-and-attest): don't push image SBOM as a release asset

### DIFF
--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -101,6 +101,13 @@ jobs:
           image: ${{ env.IMAGE_REF }}
           format: cyclonedx-json
           output-file: sbom.cdx.json
+          # The SBOM is consumed locally by the next `cosign attest` step and
+          # persisted as an OCI referrer — it must NOT be pushed as a GitHub
+          # release asset. sbom-action defaults both uploads to true and, on a
+          # tag, tries to attach to the release, which fails under this job's
+          # least-privilege `contents: read`.
+          upload-release-assets: false
+          upload-artifact: false
       - name: Attest SBOM (cosign)
         if: ${{ inputs.sbom }}
         run: |


### PR DESCRIPTION
The CycloneDX SBOM step uses `anchore/sbom-action`, whose `upload-release-assets`/`upload-artifact` default to true. On a tag run it attaches the SBOM to the GitHub Release, which 403s under the job's least-privilege `contents: read`, failing the whole sign-and-attest job. The SBOM is only needed locally for the following `cosign attest` (OCI referrer), so disable both uploads. Surfaced by nsip v0.7.0 (first real execution of the container chain; rust-template's is gated off at publish=false).