### PR TITLE
fix(sast): align codeql-action/analyze pin with init (v4.36.3)

### DIFF
--- a/.github/workflows/reusable-sast-codeql.yml
+++ b/.github/workflows/reusable-sast-codeql.yml
@@ -79,7 +79,7 @@ jobs:
           queries: ${{ inputs.queries }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: '/language:${{ inputs.languages }}'
           # Write SARIF to a directory in addition to the code-scanning upload,


### PR DESCRIPTION
## Summary
- `reusable-sast-codeql.yml`'s `init` step is pinned to `codeql-action` v4.36.3 but the `analyze` step was still pinned to v4.34.1. codeql-action requires both to run the same version and fails with `Loaded a configuration file for version '4.36.3', but running version '4.34.1'` when they diverge.
- Bumps `analyze` to `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (v4.36.3), matching `init`.

## How this was found
`zircote/rust-template` dependabot PR #135 bumped its pin of this reusable workflow to the current SHA, which surfaced the `sast / analyze` job failing with the version-mismatch error above. The 4 sibling dependabot PRs (unrelated bumps) merged cleanly with no other issues.

## Test plan
- [ ] `sast / analyze` passes on a downstream consumer after re-pinning to a SHA including this fix
